### PR TITLE
fix JS error that brake JS on whole website

### DIFF
--- a/packetery/views/js/front.js
+++ b/packetery/views/js/front.js
@@ -98,7 +98,11 @@ tools = {
 	readAjaxFields: function() {
 		var raw = $('#ajaxfields').val();
 		var json = decodeURIComponent(raw);
-		widget_lang_pac = JSON.parse(json);
+		try {
+			widget_lang_pac = JSON.parse(json);
+		} catch (e) {
+			widget_lang_pac = null;
+		}
 	},
 	checkwidgetstatus: function(extra) {
 		tools.setcoutrycontext();


### PR DESCRIPTION
I recognized that error using classic template on PrestaShop 1.7.2.x.
The whole JS on the website got broken after installing module, you're not able to put items in cart etc.