### PR TITLE
Fixed #62: `Undefined index: customer_country`

### DIFF
--- a/packetery/packetery.php
+++ b/packetery/packetery.php
@@ -659,6 +659,8 @@ class Packetery extends CarrierModule
 
                 $countryObj = new CountryCore($address->id_country);
                 $this->context->smarty->assign('customer_country', strtolower($countryObj->iso_code));
+            } else {
+                $this->context->smarty->assign('customer_country', null);
             }
 
             $this->context->smarty->assign('module_version', $this->version);


### PR DESCRIPTION
Oprava chyby `Undefined index: customer_country`, která se zobrazí, pokud uživatel nemá nastavenu adresu v košíku. Chyba v takovém případě neumožní uživatelům nakoupit v e-shopu (bez ohledu na to, jestli chtějí využít zásilkovnu nebo ne). Viz issue #62.