### PR TITLE
PES-3106: replaced direct `Smarty` instantiation with module context `Smarty` across codebase

### DIFF
--- a/packetery/controllers/admin/PacketeryCarrierGridController.php
+++ b/packetery/controllers/admin/PacketeryCarrierGridController.php
@@ -195,7 +195,7 @@ class PacketeryCarrierGridController extends ModuleAdminController
      */
     public function getIconForBoolean($booleanValue)
     {
-        $smarty = new Smarty();
+        $smarty = $this->getModule()->getContext()->smarty;
         $smarty->assign('value', $booleanValue);
 
         return $smarty->fetch(__DIR__ . '/../../views/templates/admin/grid/booleanIcon.tpl');
@@ -229,8 +229,8 @@ class PacketeryCarrierGridController extends ModuleAdminController
         /** @var CarrierTools $carrierTools */
         $carrierTools = $module->diContainer->get(CarrierTools::class);
 
-        $smarty = new Smarty();
-        $smarty->assign('link', $carrierTools->getEditLink($carrierId));
+        $smarty = $this->getModule()->getContext()->smarty;
+        $smarty->assign('linkUrl', $carrierTools->getEditLink($carrierId));
         $smarty->assign('title', $this->module->l('Edit', 'packeterycarriergridcontroller'));
         $smarty->assign('class', 'edit btn btn-default');
         $smarty->assign('icon', 'icon-pencil');

--- a/packetery/controllers/admin/PacketeryLogGridController.php
+++ b/packetery/controllers/admin/PacketeryLogGridController.php
@@ -155,9 +155,9 @@ class PacketeryLogGridController extends ModuleAdminController
      */
     public function getColumnLink($link, $columnValue)
     {
-        $smarty = new Smarty();
+        $smarty = $this->getModule()->getContext()->smarty;
         $smarty->assign([
-            'link' => $link,
+            'linkUrl' => $link,
             'columnValue' => $columnValue,
         ]);
 

--- a/packetery/controllers/admin/PacketeryOrderGridController.php
+++ b/packetery/controllers/admin/PacketeryOrderGridController.php
@@ -600,7 +600,7 @@ class PacketeryOrderGridController extends ModuleAdminController
         if (empty($trackingNumber)) {
             return '';
         }
-        $smarty = new Smarty();
+        $smarty = $this->getModule()->getContext()->smarty;
         $smarty->assign('trackingNumber', $trackingNumber);
         $smarty->assign('trackingUrl', Packetery\Module\Helper::getTrackingUrl($trackingNumber));
 
@@ -655,9 +655,9 @@ class PacketeryOrderGridController extends ModuleAdminController
      */
     public function getColumnLink($link, $columnValue)
     {
-        $smarty = new Smarty();
+        $smarty = $this->getModule()->getContext()->smarty;
         $smarty->assign([
-            'link' => $link,
+            'linkUrl' => $link,
             'columnValue' => $columnValue,
         ]);
 
@@ -673,7 +673,7 @@ class PacketeryOrderGridController extends ModuleAdminController
      */
     public function getIconForBoolean($booleanValue)
     {
-        $smarty = new Smarty();
+        $smarty = $this->getModule()->getContext()->smarty;
         $smarty->assign('value', $booleanValue);
 
         return $smarty->fetch(__DIR__ . '/../../views/templates/admin/grid/booleanIcon.tpl');
@@ -689,7 +689,7 @@ class PacketeryOrderGridController extends ModuleAdminController
      */
     public function getWeightEditable($weight, array $row)
     {
-        $smarty = new Smarty();
+        $smarty = $this->getModule()->getContext()->smarty;
         $smarty->assign('weight', $weight);
         $smarty->assign('orderId', $row['id_order']);
         $smarty->assign('disabled', $row['tracking_number']);
@@ -770,8 +770,8 @@ class PacketeryOrderGridController extends ModuleAdminController
     {
         $href = $this->getModule()->getAdminLink('PacketeryOrderGrid', ['id_order' => $orderId, 'action' => $action]);
 
-        $smarty = new Smarty();
-        $smarty->assign('link', $href);
+        $smarty = $this->getModule()->getContext()->smarty;
+        $smarty->assign('linkUrl', $href);
         $smarty->assign('title', $title);
         $smarty->assign('icon', $iconClass);
         $smarty->assign('class', 'btn btn-sm label-tooltip');

--- a/packetery/libs/Carrier/CarrierAdminForm.php
+++ b/packetery/libs/Carrier/CarrierAdminForm.php
@@ -466,7 +466,7 @@ class CarrierAdminForm
             }
         }
 
-        $smarty = new \Smarty();
+        $smarty = $this->module->getContext()->smarty;
         $smarty->assign('vendorsData', $vendorsData);
 
         return $smarty->fetch(__DIR__ . '/../../views/templates/admin/vendors.tpl');

--- a/packetery/packetery.php
+++ b/packetery/packetery.php
@@ -1633,7 +1633,7 @@ class Packetery extends CarrierModule
         try {
             $trackingNumbers = $packetSubmitter->ordersExport($orderIds);
             foreach ($trackingNumbers as $trackingNumber) {
-                $smarty = new Smarty();
+                $smarty = $this->getContext()->smarty;
                 $smarty->assign('trackingNumber', $trackingNumber);
                 $smarty->assign('trackingUrl', Packetery\Module\Helper::getTrackingUrl($trackingNumber));
                 $packeteryTrackingLink = $smarty->fetch(dirname(__FILE__) . '/views/templates/admin/trackingLink.tpl');

--- a/packetery/views/templates/admin/grid/link.tpl
+++ b/packetery/views/templates/admin/grid/link.tpl
@@ -3,4 +3,4 @@
  * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  *}
 
-<a{(isset($class)) ? " class=\"`$class`\"" : ''} href="{$link}" data-toggle="tooltip" data-original-title="{$title}"><i class="{$icon}"></i></a>
+<a{(isset($class)) ? " class=\"`$class`\"" : ''} href="{$linkUrl}" data-toggle="tooltip" data-original-title="{$title}"><i class="{$icon}"></i></a>

--- a/packetery/views/templates/admin/grid/targetBlankLink.tpl
+++ b/packetery/views/templates/admin/grid/targetBlankLink.tpl
@@ -3,4 +3,4 @@
  * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  *}
 
-<a href="{$link}" target="_blank">{$columnValue}</a>
+<a href="{$linkUrl}" target="_blank">{$columnValue}</a>


### PR DESCRIPTION
…`Smarty` across codebase