### PR TITLE
PES-3209: PHPStan – CI pojistka proti růstu baseline + dev dokumentace

### DIFF
--- a/.github/workflows/run-phpstan.yml
+++ b/.github/workflows/run-phpstan.yml
@@ -30,5 +30,17 @@ jobs:
             -   name: Install Composer dependencies
                 run: composer install
 
+            -   name: Baseline nesmí růst
+                if: github.event_name == 'pull_request'
+                run: |
+                    git fetch origin "${{ github.base_ref }}" --depth=1
+                    BASE=$(git show "origin/${{ github.base_ref }}:phpstan/phpstan-baseline.neon" 2>/dev/null | grep -c 'message:' || echo 0)
+                    HEAD=$(grep -c 'message:' phpstan/phpstan-baseline.neon || echo 0)
+                    echo "baseline: base=$BASE head=$HEAD"
+                    if [ "$HEAD" -gt "$BASE" ]; then
+                      echo "::error::Baseline narostl ($BASE -> $HEAD). Oprav kód místo regenerace baseline, nebo jde o vědomý bump levelu (commitni zvlášť a popiš v PR)."
+                      exit 1
+                    fi
+
             -   name: Run PHPStan
                 run: composer run phpstan

--- a/docs/dev/static-analysis.md
+++ b/docs/dev/static-analysis.md
@@ -1,0 +1,82 @@
+# Statická analýza (PHPStan)
+
+Tento dokument popisuje, jak v projektu funguje PHPStan, jaká pravidla kolem něj
+platí a jak postupovat, když ti na něm spadne PR.
+
+## Jak to funguje
+
+- Konfigurace: [`phpstan/phpstan.neon`](../../phpstan/phpstan.neon)
+  - `level: 2`
+  - `strictRules.allRules: true` — zapnuté přísné pravidla
+    (`phpstan/phpstan-strict-rules`): zákaz `empty()`, „only booleans in if",
+    žádné loose comparisons apod. **Většina hodnoty pochází ze strict rules, ne
+    z levelu.**
+  - PrestaShop API je PHPStanu známé přes stubs
+    (`stancer/php-stubs-prestashop`) — `Db`, `Configuration`, `Tools`, …
+- Baseline: [`phpstan/phpstan-baseline.neon`](../../phpstan/phpstan-baseline.neon)
+  — snapshot **existujícího** dluhu, který PHPStan ignoruje. Nový kód do baseline
+  nepatří.
+- CI: workflow **PHPStan Analysis**
+  ([`.github/workflows/run-phpstan.yml`](../../.github/workflows/run-phpstan.yml))
+  běží na každý PR i push do `main`. Spouští `composer run phpstan`.
+
+Výsledný model: **nový kód, který poruší level 2 / strict rules, padá v CI.**
+Baseline drží jen starý dluh, který se postupně umazává.
+
+## Pravidlo: baseline jen smršťovat
+
+Baseline se smí **jen zmenšovat**, nikdy růst. Když opravíš starý kód, odeber
+příslušné položky z baseline (PHPStan tě k tomu sám donutí — hlásí nenamatchované
+ignorované chyby).
+
+Jedinou legitimní výjimkou je **vědomé zvednutí levelu** (viz níže), kdy nové
+kontroly jednorázově odhalí další chyby ve starém kódu. To se commitne **zvlášť**
+a popíše v PR.
+
+Tohle pravidlo hlídá CI krok „Baseline nesmí růst" v `run-phpstan.yml`: porovná
+počet baselinovaných chyb na PR proti base větvi a spadne, když jich přibylo.
+
+## Spadl mi PR na PHPStanu — co s tím?
+
+1. Spusť analýzu lokálně (viz níže) a přečti si chyby.
+2. **Oprav kód.** To je správné řešení v drtivé většině případů.
+3. Regenerace baseline (`composer run phpstan-generate-baseline`) **není** způsob,
+   jak PR protlačit — propašoval bys novou chybu mezi ignorované a CI krok
+   „Baseline nesmí růst" tě stejně zastaví.
+
+## Zvedání levelu
+
+Cílový strop je **level 5**. Výš nejdeme:
+
+| Level | Chyby nad současnou baseline |
+|-------|------------------------------|
+| 3 | ~10 |
+| 4 | ~21 |
+| 5 | ~43 |
+| 6 | ~342 ❌ |
+
+Level 6 zapíná kontrolu chybějících typehintů po celém legacy kódu (+~300 chyb) —
+to je velký refactor mimo rozsah průběžné údržby, nedělá se.
+
+Postup při bumpu (jeden level = jeden PR):
+
+1. Zvedni `level:` v `phpstan/phpstan.neon` o jedna.
+2. Spusť analýzu, drobné chyby oprav přímo v kódu.
+3. Co je opravdu drahé opravit, snapshotni do baseline
+   (`composer run phpstan-generate-baseline`) — to je ten povolený jednorázový
+   růst, commitni ho zvlášť a popiš v PR.
+4. Ověř zelené CI.
+
+## Lokální spuštění
+
+```bash
+# celé QA modulu (EC + PHPCS + CS-Fixer + PHPStan), z dev-env rootu:
+make check
+
+# jen PHPStan, přímo v kontejneru:
+docker exec ps82 bash -c "cd /var/www/packetery-dev/ && composer run phpstan"
+
+# změřit dopad konkrétního levelu (chyby nad rámec baseline):
+docker exec ps82 bash -c "cd /var/www/packetery-dev/ && \
+  php -d memory_limit=2G vendor/bin/phpstan analyse -c phpstan/phpstan.neon -l 5 --no-progress"
+```


### PR DESCRIPTION
Jira: [PES-3209](https://packeta.atlassian.net/browse/PES-3209) (internal-dev)

PHPStan je v modulu už nasazený (level 2 + strict rules + baseline + CI na každý PR). Tento PR přidává dvě navazující zlepšení kolem procesu — **nemění kód modulu**, jen tooling/CI a dokumentaci.

## Změny

**1) CI pojistka proti růstu baseline** (`.github/workflows/run-phpstan.yml`)
Nový krok porovná počet baselinovaných chyb (`message:`) na PR proti base větvi a spadne, když baseline narostl. Brání propašování nové chyby do baseline regenerací místo opravy kódu. Běží jen na `pull_request`. Růst je legitimní jen při vědomém bumpu levelu (řeší se zvlášť).

**2) Dev dokumentace** (`docs/dev/static-analysis.md`)
Sdílený popis strategie: jak PHPStan funguje, pravidlo „baseline jen smršťovat", co dělat když spadne PR, postup bumpu levelu (cílový strop 5), lokální spuštění.

## Bez CHANGE_LOG záznamu
Interní dev/CI změna bez dopadu na uživatele.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PES-3209]: https://packeta.atlassian.net/browse/PES-3209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ