### PR TITLE
PES-3215: PHPStan level 2 → 4

### DIFF
--- a/packetery/controllers/admin/PacketeryOrderGridController.php
+++ b/packetery/controllers/admin/PacketeryOrderGridController.php
@@ -492,7 +492,7 @@ class PacketeryOrderGridController extends ModuleAdminController
         /** @var CollectionPrintHandler $handler */
         $handler = $this->getModule()->diContainer->get(CollectionPrintHandler::class);
 
-        $orderIds = array_map('intval', $this->boxes ?? []);
+        $orderIds = array_map('intval', $this->boxes);
         $templateVariables = $handler->handleBulkAction($orderIds);
         foreach ($templateVariables as $key => $value) {
             $this->tpl_list_vars[$key] = $value;

--- a/packetery/controllers/front/checkout.php
+++ b/packetery/controllers/front/checkout.php
@@ -20,9 +20,6 @@ class PacketeryCheckoutModuleFrontController extends ModuleFrontController
     /** @var bool */
     public $ajax = true;
 
-    /** @var Packetery */
-    public $module;
-
     public function display(): void
     {
         $token = Tools::getValue('token');
@@ -33,18 +30,29 @@ class PacketeryCheckoutModuleFrontController extends ModuleFrontController
 
         switch (Tools::getValue('action')) {
             case 'savePickupPointInCart':
-                $orderSaver = $this->module->diContainer->get(OrderSaver::class);
+                $orderSaver = $this->getModule()->diContainer->get(OrderSaver::class);
                 header('Content-Type: application/json');
                 echo $orderSaver->savePickupPointInCartGetJson();
                 break;
             case 'fetchExtraContent':
-                $packeteryCart = $this->module->diContainer->get(Cart::class);
+                $packeteryCart = $this->getModule()->diContainer->get(Cart::class);
                 echo $packeteryCart->packeteryCreateExtraContent();
                 break;
             case 'saveAddressInCart':
-                $orderAjax = $this->module->diContainer->get(Ajax::class);
+                $orderAjax = $this->getModule()->diContainer->get(Ajax::class);
                 $orderAjax->saveAddressInCart();
                 break;
         }
+    }
+
+    /**
+     * @return Packetery
+     */
+    private function getModule()
+    {
+        /** @var Packetery $module */
+        $module = $this->module;
+
+        return $module;
     }
 }

--- a/packetery/controllers/front/cron.php
+++ b/packetery/controllers/front/cron.php
@@ -26,19 +26,14 @@ class PacketeryCronModuleFrontController extends ModuleFrontController
     /** @var bool */
     private $hasError = false;
 
-    /** @var Packetery */
-    public $module;
-
     /**
-     * @return void
-     *
      * @throws PrestaShopDatabaseException
      * @throws PrestaShopException
      * @throws ReflectionException
      * @throws Packetery\Exceptions\DatabaseException
      * @throws SmartyException
      */
-    public function display()
+    public function display(): void
     {
         ignore_user_abort(true); // Ignore connection-closing by the client/user
 
@@ -82,27 +77,27 @@ class PacketeryCronModuleFrontController extends ModuleFrontController
 
         switch ($task) {
             case DeleteLabels::getTaskName():
-                $deleteLabels = $this->module->diContainer->get(DeleteLabels::class);
+                $deleteLabels = $this->getModule()->diContainer->get(DeleteLabels::class);
                 $errors = $deleteLabels->execute();
                 $this->renderErrors($errors);
                 break;
             case DownloadCarriers::getTaskName():
-                $downloadCarriers = $this->module->diContainer->get(DownloadCarriers::class);
+                $downloadCarriers = $this->getModule()->diContainer->get(DownloadCarriers::class);
                 $errors = $downloadCarriers->execute();
                 $this->renderErrors($errors);
                 break;
             case PurgeLogs::getTaskName():
-                $purgeLogs = $this->module->diContainer->get(PurgeLogs::class);
+                $purgeLogs = $this->getModule()->diContainer->get(PurgeLogs::class);
                 $errors = $purgeLogs->execute();
                 $this->renderErrors($errors);
                 break;
             case UpdatePacketStatus::getTaskName():
-                $updatePacketStatus = $this->module->diContainer->get(UpdatePacketStatus::class);
+                $updatePacketStatus = $this->getModule()->diContainer->get(UpdatePacketStatus::class);
                 $errors = $updatePacketStatus->execute();
                 $this->renderErrors($errors);
                 break;
             case GetConsignPassword::getTaskName():
-                $getConsignPassword = $this->module->diContainer->get(GetConsignPassword::class);
+                $getConsignPassword = $this->getModule()->diContainer->get(GetConsignPassword::class);
                 $messages = $getConsignPassword->execute(
                     (int) Tools::getValue('max_orders', GetConsignPassword::DEFAULT_MAX_ORDERS),
                     (int) Tools::getValue('max_order_age_days', GetConsignPassword::DEFAULT_MAX_ORDER_AGE_DAYS)
@@ -172,6 +167,17 @@ class PacketeryCronModuleFrontController extends ModuleFrontController
         $this->hasError = true;
         $this->renderMessage('[' . $this->module->l('ERROR', 'cron') . ']: ' . $message);
         PrestaShopLogger::addLog('[packetery:cron]: ' . $message, 3, null, null, null, true);
+    }
+
+    /**
+     * @return Packetery
+     */
+    private function getModule()
+    {
+        /** @var Packetery $module */
+        $module = $this->module;
+
+        return $module;
     }
 
     /**

--- a/packetery/libs/AbstractFormService.php
+++ b/packetery/libs/AbstractFormService.php
@@ -73,7 +73,7 @@ abstract class AbstractFormService
 
     /**
      * @param string $option
-     * @param array{type: string, values: array{query: array{id: string}}} $optionConfig
+     * @param array{type: string, values: array{query: list<array{id: string}>}} $optionConfig
      *
      * @return void
      *

--- a/packetery/libs/Carrier/CarrierAdminForm.php
+++ b/packetery/libs/Carrier/CarrierAdminForm.php
@@ -553,7 +553,7 @@ class CarrierAdminForm
      * @param array $formData
      * @param array|bool|object|null $carrierData
      *
-     * @return array|null
+     * @return array
      *
      * @throws DatabaseException
      */

--- a/packetery/libs/DI/Container.php
+++ b/packetery/libs/DI/Container.php
@@ -81,19 +81,11 @@ class Container
         $instances = [];
         $params = $constructorReflection->getParameters();
         foreach ($params as $param) {
-            if (PHP_VERSION_ID >= 70100) {
-                $paramType = $param->getType();
-                if (!$paramType instanceof \ReflectionNamedType || $paramType->isBuiltin()) {
-                    throw new \Exception(self::EXCEPTION_MESSAGE);
-                }
-                $className = $paramType->getName();
-            } else {
-                $paramClass = $param->getClass();
-                if ($paramClass === null) {
-                    throw new \Exception(self::EXCEPTION_MESSAGE);
-                }
-                $className = $paramClass->name;
+            $paramType = $param->getType();
+            if (!$paramType instanceof \ReflectionNamedType || $paramType->isBuiltin()) {
+                throw new \Exception(self::EXCEPTION_MESSAGE);
             }
+            $className = $paramType->getName();
 
             $instances[] = $this->get($className);
         }

--- a/packetery/libs/Module/SoapApi.php
+++ b/packetery/libs/Module/SoapApi.php
@@ -221,7 +221,7 @@ class SoapApi
      *
      * @param \SoapFault $exception
      *
-     * @return int|string
+     * @return string
      */
     private function getFaultIdentifier(\SoapFault $exception)
     {

--- a/packetery/libs/Order/PacketSubmitter.php
+++ b/packetery/libs/Order/PacketSubmitter.php
@@ -182,7 +182,7 @@ class PacketSubmitter
             }
         }
 
-        if (is_array($errors) && $errors !== []) {
+        if ($errors !== []) {
             throw new AggregatedException($errors);
         }
 
@@ -218,10 +218,7 @@ class PacketSubmitter
      */
     private function getErrorMessage(\SoapFault $e)
     {
-        $errorMessage = '';
-        if (isset($e->faultstring)) {
-            $errorMessage = $e->faultstring;
-        }
+        $errorMessage = $e->faultstring;
         if (isset($e->detail->PacketAttributesFault->attributes->fault)) {
             if (
                 is_array($e->detail->PacketAttributesFault->attributes->fault)

--- a/packetery/libs/PacketTracking/PacketStatusTrackingFormService.php
+++ b/packetery/libs/PacketTracking/PacketStatusTrackingFormService.php
@@ -106,7 +106,7 @@ class PacketStatusTrackingFormService extends AbstractFormService
     }
 
     /**
-     * @return array<int, array<string, string>>
+     * @return list<array{id: int, name: string}>
      */
     private function getPacketStatusChoices()
     {

--- a/packetery/libs/PickupPointValidate/ValidatedPoint.php
+++ b/packetery/libs/PickupPointValidate/ValidatedPoint.php
@@ -20,7 +20,7 @@ class ValidatedPoint
     /** @var string|null */
     private $carrierId;
 
-    /** @var bool|null */
+    /** @var string|null */
     private $carrierPickupPointId;
 
     public function __construct(

--- a/packetery/libs/Request/PickupPointValidateRequest.php
+++ b/packetery/libs/Request/PickupPointValidateRequest.php
@@ -32,7 +32,7 @@ class PickupPointValidateRequest
     }
 
     /**
-     * @return array<string, string|bool|float|null>
+     * @return array<string, array<string, string|bool|float|null>>
      */
     public function getSubmittableData(): array
     {

--- a/packetery/libs/Tools/ConfigHelper.php
+++ b/packetery/libs/Tools/ConfigHelper.php
@@ -175,7 +175,7 @@ class ConfigHelper
     {
         $apiPass = $this->getApiPass();
         if ($apiPass === false) {
-            return false;
+            throw InvalidApiKeyException::createFromMissingKey();
         }
 
         $apiKey = self::getApiKeyFromApiPass($apiPass);

--- a/packetery/packetery.php
+++ b/packetery/packetery.php
@@ -1566,7 +1566,7 @@ class Packetery extends CarrierModule
         /** @var Cart $cart */
         $cart = $params['cart'];
         $oldCart = new CartCore($cart->id);
-        if (!is_object($oldCart)) {
+        if (!Validate::isLoadedObject($oldCart)) {
             return;
         }
 

--- a/phpstan/phpstan.neon
+++ b/phpstan/phpstan.neon
@@ -11,6 +11,13 @@ parameters:
 		allRules: true
 	treatPhpDocTypesAsCertain: false
 	ignoreErrors:
+		# Stub inaccuracy: our display(): void overrides FrontController::display(), declared @return bool in the stub.
+		# Cannot be fixed in code — the PS Validator forbids returning a value from display().
+		-
+			identifier: method.childReturnType
+			paths:
+				- ../packetery/controllers/front/checkout.php
+				- ../packetery/controllers/front/cron.php
 	bootstrapFiles:
 	paths:
 		- ../packetery

--- a/phpstan/phpstan.neon
+++ b/phpstan/phpstan.neon
@@ -6,10 +6,13 @@ parameters:
 		max: 80100
 	fileExtensions:
 		- php
-	level: 2
+	level: 4
 	strictRules:
 		allRules: true
 	treatPhpDocTypesAsCertain: false
+	dynamicConstantNames:
+		- _PS_MODE_DEV_
+		- _PACKETERY_DEBUG_LOG_
 	ignoreErrors:
 		# Stub inaccuracy: our display(): void overrides FrontController::display(), declared @return bool in the stub.
 		# Cannot be fixed in code — the PS Validator forbids returning a value from display().


### PR DESCRIPTION
**zahrnuty 2 netriviální úpravy:**
1. `$oldCart = new CartCore($cart->id)` byl dead-code: konstruktor v PrestaShopu                                                                                           vždy vrátí objekt, takže `is_object($oldCart)` je vždy true . 
- Autor zde nejspíš chtěl ověřit, že se starý košík opravdu načetl z DB (validní ID), ale k tomu slouží `Validate::isLoadedObject()`. 

2. `ConfigHelper::getValidApiKey()` má návratový typ `: string`, ale při chybějícím API hesle vrácela `false`                                                                                  
- Protože v souboru chybí `declare(strict_types=1)`, nešlo o fatal (auto-přetypování na '')                      
- Nově vyhazuje `InvalidApiKeyException` konzistentně s druhou větví metody; pickupPointValidator ji zachytává.                                                                                         
- Bez funkční změny chování modulu. 
