### PR TITLE
PES-3188: Remove duplicate carrier lookup in admin order detail

### DIFF
--- a/packetery/CHANGE_LOG.txt
+++ b/packetery/CHANGE_LOG.txt
@@ -3,6 +3,7 @@
        - Fixed: Fix error during the export of Packeta order list.
        - Update: Packetery configuration section divided into two tabs.
        - Added: Log Packeta widget parameters to the developers console.
+       - Updated: Removed a duplicate carrier lookup in the order detail.
 3.5.0  - Added: Z-BOX consign password column in the bill of delivery print, visible only when the "Show consign password for Z-BOX" option is enabled.
        - Added: Option to display the Z-BOX consign password in the order detail. The password is retrieved either immediately when the packet is submitted, or in bulk via a cron task.
        - Updated: Add bill of delivery print to group actions of Packetery order grid

--- a/packetery/packetery.php
+++ b/packetery/packetery.php
@@ -1120,15 +1120,6 @@ class Packetery extends CarrierModule
 
         $this->context->smarty->assign('isExported', $isExported);
 
-        /** @var Packetery\Carrier\CarrierRepository $carrierRepository */
-        $carrierRepository = $this->diContainer->get(Packetery\Carrier\CarrierRepository::class);
-        $packeteryCarrier = $carrierRepository->getPacketeryCarrierById((int) $packeteryOrder['id_carrier']);
-        if ((bool) $packeteryCarrier === false) {
-            $oldCarrier = new Carrier($packeteryOrder['id_carrier']);
-            $newCarrier = Carrier::getCarrierByReference($oldCarrier->id_reference);
-            $packeteryCarrier = $carrierRepository->getPacketeryCarrierById($newCarrier->id);
-        }
-
         /** @var Packetery\Tools\ConfigHelper $configHelper */
         $configHelper = $this->diContainer->get(Packetery\Tools\ConfigHelper::class);
         $apiKey = $configHelper->getApiKey();


### PR DESCRIPTION
[PES-3188](https://packeta.atlassian.net/browse/PES-3188)

Removes a duplicate, unguarded carrier lookup in the admin order detail (packeteryHookDisplayAdminOrder) that re-queried the same carrier and could trigger a PHP warning when Carrier::getCarrierByReference() returned false. The carrier resolved by the first guarded block is reused; behaviour is unchanged.


[PES-3188]: https://packeta.atlassian.net/browse/PES-3188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ