### PR TITLE
PES-3249: allow overriding SOAP WSDL URL via config constant

### DIFF
--- a/packetery/libs/Module/SoapApi.php
+++ b/packetery/libs/Module/SoapApi.php
@@ -46,6 +46,15 @@ class SoapApi
         $this->configHelper = $configHelper;
     }
 
+    public function resolveWsdlUrl(): string
+    {
+        if (defined('_PACKETERY_SOAP_WSDL_URL_') && _PACKETERY_SOAP_WSDL_URL_ !== '') {
+            return _PACKETERY_SOAP_WSDL_URL_;
+        }
+
+        return self::WSDL_URL;
+    }
+
     /**
      * @param string $senderIndication
      * @param false|string $apiPassword
@@ -57,7 +66,7 @@ class SoapApi
      */
     public function senderGetReturnRouting($senderIndication, $apiPassword)
     {
-        $client = new \SoapClient(self::WSDL_URL);
+        $client = new \SoapClient($this->resolveWsdlUrl());
         try {
             $response = $client->senderGetReturnRouting($apiPassword, $senderIndication);
 
@@ -83,7 +92,7 @@ class SoapApi
     {
         $packetInfo = new PacketInfo();
         try {
-            $client = new \SoapClient(self::WSDL_URL);
+            $client = new \SoapClient($this->resolveWsdlUrl());
             // get PacketInfoResult
             $response = $client->packetInfo($this->configHelper->getApiPass(), $packetId);
             if (
@@ -153,7 +162,7 @@ class SoapApi
     {
         $response = new PacketCarrierNumber();
         try {
-            $soapClient = new \SoapClient(self::WSDL_URL);
+            $soapClient = new \SoapClient($this->resolveWsdlUrl());
             $number = $soapClient->packetCourierNumber($this->configHelper->getApiPass(), $packetId);
             $response->setNumber($number);
         } catch (\SoapFault $exception) {
@@ -239,7 +248,7 @@ class SoapApi
      */
     public function getPacketTracking($packetId)
     {
-        $client = new \SoapClient(self::WSDL_URL);
+        $client = new \SoapClient($this->resolveWsdlUrl());
         try {
             $response = $client->packetTracking($this->configHelper->getApiPass(), $packetId);
         } catch (\SoapFault $exception) {
@@ -260,7 +269,7 @@ class SoapApi
     {
         $response = new Packetery\Response\PacketsLabelsPdfResponse();
         try {
-            $soapClient = new \SoapClient(self::WSDL_URL);
+            $soapClient = new \SoapClient($this->resolveWsdlUrl());
             $pdfContents = $soapClient->packetsLabelsPdf($this->configHelper->getApiPass(), $packets, $format, $offset);
             $response->setPdfContents($pdfContents);
         } catch (\SoapFault $exception) {
@@ -286,7 +295,7 @@ class SoapApi
     {
         $response = new Packetery\Response\PacketsCourierLabelsPdfResponse();
         try {
-            $soapClient = new \SoapClient(self::WSDL_URL);
+            $soapClient = new \SoapClient($this->resolveWsdlUrl());
             $pdfContents = $soapClient->packetsCourierLabelsPdf($this->configHelper->getApiPass(), $packetsEnhanced, $offset, $format);
             $response->setPdfContents($pdfContents);
         } catch (\SoapFault $exception) {
@@ -308,7 +317,7 @@ class SoapApi
     {
         $response = new CancelPacketResponse();
         try {
-            $soapClient = new \SoapClient(self::WSDL_URL);
+            $soapClient = new \SoapClient($this->resolveWsdlUrl());
             $soapClient->cancelPacket($this->configHelper->getApiPass(), $request->getPacketId());
         } catch (\SoapFault $exception) {
             $response->setFault($this->getFaultIdentifier($exception));
@@ -323,7 +332,7 @@ class SoapApi
         $response = new Packetery\Response\CreateShipmentResponse();
 
         try {
-            $soapClient = new \SoapClient(self::WSDL_URL);
+            $soapClient = new \SoapClient($this->resolveWsdlUrl());
             $result = $soapClient->createShipment($this->configHelper->getApiPass(), $packetIds);
         } catch (\SoapFault $exception) {
             $response->setFault($this->getFaultIdentifier($exception));
@@ -342,7 +351,7 @@ class SoapApi
         $response = new Packetery\Response\BarcodePngResponse();
 
         try {
-            $soapClient = new \SoapClient(self::WSDL_URL);
+            $soapClient = new \SoapClient($this->resolveWsdlUrl());
             $imageData = $soapClient->barcodePng($this->configHelper->getApiPass(), $barcode);
         } catch (\SoapFault $exception) {
             $response->setFault($this->getFaultIdentifier($exception));

--- a/packetery/libs/Order/PacketSubmitter.php
+++ b/packetery/libs/Order/PacketSubmitter.php
@@ -35,19 +35,23 @@ class PacketSubmitter
     private $configHelper;
     /** @var ConsignPasswordProvider */
     private $consignPasswordProvider;
+    /** @var SoapApi */
+    private $soapApi;
 
     public function __construct(
         OrderRepository $orderRepository,
         LogRepository $logRepository,
         \Packetery $module,
         ConfigHelper $configHelper,
-        ConsignPasswordProvider $consignPasswordProvider
+        ConsignPasswordProvider $consignPasswordProvider,
+        SoapApi $soapApi
     ) {
         $this->orderRepository = $orderRepository;
         $this->logRepository = $logRepository;
         $this->module = $module;
         $this->configHelper = $configHelper;
         $this->consignPasswordProvider = $consignPasswordProvider;
+        $this->soapApi = $soapApi;
     }
 
     /**
@@ -198,7 +202,7 @@ class PacketSubmitter
      */
     private function createPacketSoap(array $packetAttributes)
     {
-        $client = new \SoapClient(SoapApi::WSDL_URL);
+        $client = new \SoapClient($this->soapApi->resolveWsdlUrl());
         try {
             $trackingNumber = $client->createPacket($this->configHelper->getApiPass(), $packetAttributes);
             if (isset($trackingNumber->id) && is_string($trackingNumber->id) && \Tools::strlen($trackingNumber->id) > 0) {


### PR DESCRIPTION
- nepřidávám changelog, je to interní věc pro packetu
- cli mód ověřen skriptem
- PS validator: /libs/Order/PacketSubmitter.php , blank_line_after_opening_tag, trailing_comma_in_multiline řádek 47 s SoapApi·$soapApi je false-positive. A jen se posunul stávající výskyt o řádek. Přidat čárku lze až od PHP 7.3, ale podporujeme již 7.1.
