### PR TITLE
PES-3252: Order list - creation and cancel the return packet

### DIFF
--- a/packetery/CHANGE_LOG.txt
+++ b/packetery/CHANGE_LOG.txt
@@ -6,6 +6,7 @@
        - Updated: Removed a duplicate carrier lookup in the order detail.
 3.5.0  - Added: Consignment code column in the bill of delivery print, visible only when the "Show consignment code" option is enabled.
        - Added: Option to display the consignment code in the order detail. The code is retrieved either immediately when the packet is submitted, or in bulk via a cron task.
+       - Added: Option to create and cancel a return shipment directly from the Packeta order list.
        - Updated: Add bill of delivery print to group actions of Packetery order grid
        - Fixed: Let Widget Validation option only for CZ/SK carriers in carrier administration
        - Updated: Removed displaying "is COD" flag.

--- a/packetery/controllers/admin/PacketeryOrderGridController.php
+++ b/packetery/controllers/admin/PacketeryOrderGridController.php
@@ -14,6 +14,10 @@ use Packetery\Exceptions\DatabaseException;
 use Packetery\Exceptions\LabelPrintException;
 use Packetery\Module\SoapApi;
 use Packetery\Module\VersionChecker;
+use Packetery\Order\ClaimCanceller;
+use Packetery\Order\ClaimEligibility;
+use Packetery\Order\ClaimFault;
+use Packetery\Order\ClaimSubmitter;
 use Packetery\Order\CollectionPrintHandler;
 use Packetery\Order\CsvExporter;
 use Packetery\Order\Labels;
@@ -31,6 +35,13 @@ class PacketeryOrderGridController extends ModuleAdminController
     public const ACTION_BULK_LABEL_PDF = 'bulkLabelPdf';
     public const ACTION_BULK_CARRIER_LABEL_PDF = 'bulkCarrierLabelPdf';
     public const ACTION_BULK_COLLECTION_PRINT = 'bulkCollectionPrint';
+    public const ACTION_CREATE_CLAIM = 'createClaim';
+    public const ACTION_CANCEL_CLAIM = 'cancelClaim';
+
+    /**
+     * Filter key of the "Tracking number" search box; the actual filtering happens in processFilter().
+     */
+    private const TRACKING_SEARCH_KEY = 'tracking_search';
 
     /** @var array */
     protected $statuses_array = [];
@@ -71,6 +82,7 @@ class PacketeryOrderGridController extends ModuleAdminController
             `po`.`zip`,
             `po`.`exported`,
             IF(`po`.`tracking_number` IS NOT NULL, `po`.`tracking_number`, \'\') AS `tracking_number`,
+            `po`.`claim_id`,
             CONCAT(LEFT(c.`firstname`, 1), \'. \', c.`lastname`) AS `customer`,
             IF(`a`.`valid`, 1, 0) AS `badge_success`,
             CAST(`po`.`weight` AS DECIMAL(10,2)) AS `weight`,
@@ -169,7 +181,7 @@ class PacketeryOrderGridController extends ModuleAdminController
             'tracking_number' => [
                 'title' => $this->module->l('Tracking number', 'packeteryordergridcontroller'),
                 'callback' => 'getTrackingLink',
-                'filter_key' => 'po!tracking_number',
+                'filter_key' => self::TRACKING_SEARCH_KEY,
                 'search' => true,
                 'orderby' => false,
             ],
@@ -464,6 +476,221 @@ class PacketeryOrderGridController extends ModuleAdminController
         }
     }
 
+    public function processCreateClaim(): void
+    {
+        $module = $this->getModule();
+        $orderId = (int) Tools::getValue('id_order');
+
+        /** @var OrderRepository $orderRepository */
+        $orderRepository = $module->diContainer->get(OrderRepository::class);
+        /** @var PacketTrackingRepository $packetTrackingRepository */
+        $packetTrackingRepository = $module->diContainer->get(PacketTrackingRepository::class);
+        /** @var ClaimEligibility $claimEligibility */
+        $claimEligibility = $module->diContainer->get(ClaimEligibility::class);
+
+        $orderData = $orderRepository->getOrderWithCountry($orderId);
+        $trackingNumber = $orderData['tracking_number'] ?? null;
+        $lastStatusCode = $trackingNumber !== null
+            ? $packetTrackingRepository->getLastStatusCodeByOrderAndPacketId($orderId, $trackingNumber)
+            : null;
+        $deliveryCountry = $orderData['ps_country'] ?? null;
+        $existingClaimId = $orderData['claim_id'] ?? null;
+
+        $errorMessage = $this->module->l('The return could not be created.', 'packeteryordergridcontroller');
+
+        if (
+            !$this->isOrderInShopContext($orderId)
+            || !$claimEligibility->canCreateClaim(
+                $trackingNumber,
+                $lastStatusCode,
+                $deliveryCountry,
+                $existingClaimId
+            )
+        ) {
+            // server-side gate: the icon is hidden in this state, so this is a forged/stale call
+            $this->errors[] = $errorMessage;
+
+            return;
+        }
+
+        /** @var ClaimSubmitter $claimSubmitter */
+        $claimSubmitter = $module->diContainer->get(ClaimSubmitter::class);
+        $response = $claimSubmitter->submit($orderId);
+
+        if (!$response->hasFault()) {
+            $this->informations[] = $this->module->l('The return was successfully created.', 'packeteryordergridcontroller');
+
+            return;
+        }
+
+        $this->addClaimFaultFlash(
+            $response->getFault(),
+            $response->getFaultString(),
+            $errorMessage,
+            $this->module->l('The return could not be created. More information can be found in the log.', 'packeteryordergridcontroller'),
+            $orderId
+        );
+    }
+
+    public function processCancelClaim(): void
+    {
+        $module = $this->getModule();
+        $orderId = (int) Tools::getValue('id_order');
+
+        /** @var OrderRepository $orderRepository */
+        $orderRepository = $module->diContainer->get(OrderRepository::class);
+        $orderData = $orderRepository->getById($orderId);
+
+        $existingClaimId = $orderData['claim_id'] ?? null;
+
+        /** @var ClaimEligibility $claimEligibility */
+        $claimEligibility = $module->diContainer->get(ClaimEligibility::class);
+
+        $errorMessage = sprintf(
+            $this->module->l('The return for order no.: %d could not be cancelled.', 'packeteryordergridcontroller'),
+            $orderId
+        );
+
+        if (
+            !$this->isOrderInShopContext($orderId)
+            || !$claimEligibility->canCancelClaim($existingClaimId)
+        ) {
+            // server-side gate: the icon is hidden in this state, so this is a forged/stale call
+            $this->errors[] = $errorMessage;
+
+            return;
+        }
+
+        /** @var ClaimCanceller $claimCanceller */
+        $claimCanceller = $module->diContainer->get(ClaimCanceller::class);
+        $response = $claimCanceller->cancel($orderId);
+
+        if (!$response->hasFault()) {
+            $this->informations[] = sprintf(
+                $this->module->l('The return for order no.: %d was successfully cancelled in Packeta.', 'packeteryordergridcontroller'),
+                $orderId
+            );
+
+            return;
+        }
+
+        $apiLogMessage = sprintf(
+            $this->module->l('The return for order no.: %d could not be cancelled. More information can be found in the log.', 'packeteryordergridcontroller'),
+            $orderId
+        );
+        $this->addClaimFaultFlash(
+            $response->getFault(),
+            $response->getFaultString(),
+            $errorMessage,
+            $apiLogMessage,
+            $orderId
+        );
+    }
+
+    /**
+     * Adds the right flash for a claim fault and logs it where the person who can act on it looks:
+     * a missing customer contact is fixable, so it gets a specific translated flash and no log;
+     * a DB write that failed after a successful API call gets a flash that says the action happened
+     * in Packeta plus a PrestaShop-log orphan trace;
+     * an API fault is already in the module API log, so the flash points there;
+     * the other pre-API faults are flash-only.
+     */
+    private function addClaimFaultFlash(
+        ?string $fault,
+        ?string $faultString,
+        string $genericMessage,
+        string $apiLogMessage,
+        int $orderId
+    ): void {
+        if ($fault === ClaimFault::EMAIL_MISSING || $fault === ClaimFault::PHONE_MISSING) {
+            $this->errors[] = $this->getMissingContactMessage($fault);
+
+            return;
+        }
+
+        if ($fault === ClaimFault::CLAIM_NOT_SAVED || $fault === ClaimFault::CLAIM_NOT_CLEARED) {
+            $this->logClaimFaultToPrestaShop($faultString, $orderId);
+            $this->errors[] = $this->getOrphanMessage($fault, $orderId);
+
+            return;
+        }
+
+        $flashOnlyFaults = [
+            ClaimFault::ORDER_NOT_FOUND,
+            ClaimFault::ESHOP_ID_MISSING,
+            ClaimFault::VALUE_UNRESOLVED,
+        ];
+
+        if (in_array($fault, $flashOnlyFaults, true)) {
+            $this->errors[] = $genericMessage;
+
+            return;
+        }
+
+        // NO_CLAIM_ID or a real API fault: already written to the module API log
+        $this->errors[] = $apiLogMessage;
+    }
+
+    /**
+     * Actionable flash for a return that the operator can fix by completing the order contact
+     */
+    private function getMissingContactMessage(string $fault): string
+    {
+        if ($fault === ClaimFault::EMAIL_MISSING) {
+            return $this->module->l('Customer email is missing. Add it to the order and try again.', 'packeteryordergridcontroller');
+        }
+
+        return $this->module->l('Customer phone is missing. Add it to the order and try again.', 'packeteryordergridcontroller');
+    }
+
+    /**
+     * Truthful flash for an orphaned return: the Packeta action succeeded, only the local write failed
+     */
+    private function getOrphanMessage(string $fault, int $orderId): string
+    {
+        if ($fault === ClaimFault::CLAIM_NOT_SAVED) {
+            return $this->module->l('The return was created in Packeta but could not be saved to the order. See the PrestaShop log.', 'packeteryordergridcontroller');
+        }
+
+        return sprintf(
+            $this->module->l('The return for order no.: %d was cancelled in Packeta but could not be cleared from the order. See the PrestaShop log.', 'packeteryordergridcontroller'),
+            $orderId
+        );
+    }
+
+    /**
+     * Records an orphaned-return claim fault in the PrestaShop log (linked to the order);
+     * mirrors PacketCanceller.
+     */
+    private function logClaimFaultToPrestaShop(?string $faultString, int $orderId): void
+    {
+        PrestaShopLogger::addLog((string) $faultString, 3, null, 'PacketeryOrder', $orderId, true);
+    }
+
+    /**
+     * Guards a forged id_order from another shop: a claim action may only touch an order the
+     * current shop context covers, mirroring the order grid shop scoping
+     */
+    private function isOrderInShopContext(int $orderId): bool
+    {
+        $order = new Order($orderId);
+        if (!Validate::isLoadedObject($order)) {
+            return false;
+        }
+
+        $shopId = Shop::getContextShopID(true);
+        if ($shopId !== null && (int) $order->id_shop !== (int) $shopId) {
+            return false;
+        }
+
+        $groupId = Shop::getContextShopGroupID(true);
+        if ($groupId !== null && (int) $order->id_shop_group !== (int) $groupId) {
+            return false;
+        }
+
+        return true;
+    }
+
     public function processBulkCsvExport()
     {
         if ((int) Tools::getValue('submitFilterorders') === 1) {
@@ -602,6 +829,61 @@ class PacketeryOrderGridController extends ModuleAdminController
         unset($this->toolbar_btn['new']);
     }
 
+    /**
+     * Filters the "Tracking number" search across both base columns. The framework filters one
+     * column per filter_key, so the field is hidden from its filter building and a substring match
+     * over both columns is appended to the WHERE clause instead, keeping the framework's default
+     * `%value%` behaviour for the existing tracking-number search.
+     */
+    public function processFilter()
+    {
+        $field = $this->fields_list['tracking_number'] ?? null;
+        $hasFilterKey = is_array($field) && array_key_exists('filter_key', $field);
+        if ($hasFilterKey) {
+            unset($this->fields_list['tracking_number']['filter_key']);
+        }
+
+        parent::processFilter();
+
+        if ($hasFilterKey) {
+            $this->fields_list['tracking_number']['filter_key'] = $field['filter_key'];
+        }
+
+        $value = $this->getTrackingSearchValue();
+        if ($value === '') {
+            return;
+        }
+
+        $escaped = pSQL($value);
+        $this->_filter .= ' AND (`po`.`tracking_number` LIKE \'%' . $escaped . '%\''
+            . ' OR `po`.`claim_id` LIKE \'%' . $escaped . '%\') ';
+    }
+
+    /**
+     * Reads the submitted "Tracking number" search value from the request or the persisted filter
+     * cookie, mirroring how the framework resolves list filter values.
+     *
+     * @return string
+     */
+    private function getTrackingSearchValue(): string
+    {
+        $listId = $this->list_id ?? $this->table;
+        $name = $listId . 'Filter_' . self::TRACKING_SEARCH_KEY;
+
+        $value = Tools::getValue($name);
+        if ($value === false || $value === null || $value === '') {
+            $cookieKey = $this->getCookieFilterPrefix() . $name;
+            $cookie = $this->context->cookie;
+            $value = $cookie->__isset($cookieKey) ? $cookie->__get($cookieKey) : '';
+        }
+
+        if (!is_string($value)) {
+            return '';
+        }
+
+        return trim($value);
+    }
+
     public function postProcess()
     {
         // values are saved even before bulk actions
@@ -642,14 +924,26 @@ class PacketeryOrderGridController extends ModuleAdminController
      * @throws ReflectionException
      * @throws SmartyException
      */
-    public function getTrackingLink($trackingNumber)
+    public function getTrackingLink($trackingNumber, array $row = [])
     {
         if (empty($trackingNumber)) {
             return '';
         }
+        $claimNumber = (isset($row['claim_id']) && $row['claim_id'] !== '')
+            ? (string) $row['claim_id']
+            : null;
+
+        $claimUrl = '';
+        if ($claimNumber !== null) {
+            $claimUrl = Packetery\Module\Helper::getTrackingUrl($claimNumber);
+        }
+
         $smarty = $this->getModule()->getContext()->smarty;
         $smarty->assign('trackingNumber', $trackingNumber);
         $smarty->assign('trackingUrl', Packetery\Module\Helper::getTrackingUrl($trackingNumber));
+        $smarty->assign('claimNumber', $claimNumber);
+        $smarty->assign('claimUrl', $claimUrl);
+        $smarty->assign('claimLabel', $this->module->l('Return:', 'packeteryordergridcontroller'));
 
         return $smarty->fetch(__DIR__ . '/../../views/templates/admin/trackingLink.tpl');
     }
@@ -803,6 +1097,8 @@ class PacketeryOrderGridController extends ModuleAdminController
                 $title = $this->module->l('Cancel Packet', 'packeteryordergridcontroller');
                 $links[$action] = $this->getActionLinkHtml($orderId, $action, $title, $iconClass);
             }
+
+            $links += $this->getClaimActionLinks($orderId, $orderData, $lastStatusCode);
         } else {
             $action = 'submit';
             $iconClass = 'icon-send';
@@ -813,17 +1109,88 @@ class PacketeryOrderGridController extends ModuleAdminController
         return $links;
     }
 
-    private function getActionLinkHtml(int $orderId, string $action, string $title, string $iconClass): string
+    /**
+     * @param array $orderData packetery_order row
+     * @param int|null $lastStatusCode
+     *
+     * @return array
+     */
+    private function getClaimActionLinks(int $orderId, array $orderData, ?int $lastStatusCode): array
     {
+        $module = $this->getModule();
+
+        /** @var ClaimEligibility $claimEligibility */
+        $claimEligibility = $module->diContainer->get(ClaimEligibility::class);
+        $claimId = $orderData['claim_id'] ?? null;
+
+        if ($claimEligibility->canCancelClaim($claimId)) {
+            return [
+                self::ACTION_CANCEL_CLAIM => $this->getActionLinkHtml(
+                    $orderId,
+                    self::ACTION_CANCEL_CLAIM,
+                    $this->module->l('Cancel return', 'packeteryordergridcontroller'),
+                    'icon-ban',
+                    $this->module->l('Do you really wish to cancel the return?', 'packeteryordergridcontroller')
+                ),
+            ];
+        }
+
+        if ($lastStatusCode !== PacketStatus::DELIVERED) {
+            return [];
+        }
+
+        /** @var OrderRepository $orderRepository */
+        $orderRepository = $module->diContainer->get(OrderRepository::class);
+        $orderWithCountry = $orderRepository->getOrderWithCountry($orderId);
+        $deliveryCountry = $orderWithCountry['ps_country'] ?? null;
+
+        if (
+            $claimEligibility->canCreateClaim(
+                $orderData['tracking_number'],
+                $lastStatusCode,
+                $deliveryCountry,
+                $claimId
+            )
+        ) {
+            return [
+                self::ACTION_CREATE_CLAIM => $this->getActionLinkHtml(
+                    $orderId,
+                    self::ACTION_CREATE_CLAIM,
+                    $this->module->l('Create return', 'packeteryordergridcontroller'),
+                    'icon-reply',
+                    $this->module->l('Do you really wish to create the return? The customer will be notified by email.', 'packeteryordergridcontroller')
+                ),
+            ];
+        }
+
+        return [];
+    }
+
+    /**
+     * Renders a grid action link in an isolated Smarty scope so its variables do not leak into the page context
+     */
+    private function getActionLinkHtml(
+        int $orderId,
+        string $action,
+        string $title,
+        string $iconClass,
+        string $confirmMessage = ''
+    ): string {
         $href = $this->getModule()->getAdminLink('PacketeryOrderGrid', ['id_order' => $orderId, 'action' => $action]);
 
         $smarty = $this->getModule()->getContext()->smarty;
-        $smarty->assign('linkUrl', $href);
-        $smarty->assign('title', $title);
-        $smarty->assign('icon', $iconClass);
-        $smarty->assign('class', 'btn btn-sm label-tooltip');
+        $template = $smarty->createTemplate(
+            __DIR__ . '/../../views/templates/admin/grid/link.tpl',
+            [
+                'linkUrl' => $href,
+                'title' => $title,
+                'icon' => $iconClass,
+                'class' => 'btn btn-sm label-tooltip',
+                'confirmMessage' => $confirmMessage,
+            ]
+        );
 
-        return $smarty->fetch(__DIR__ . '/../../views/templates/admin/grid/link.tpl');
+        return $template->fetch();
     }
 
     /**

--- a/packetery/libs/Carrier/CarrierAdminForm.php
+++ b/packetery/libs/Carrier/CarrierAdminForm.php
@@ -50,8 +50,6 @@ class CarrierAdminForm
     /** @var CarrierFieldsResolver */
     private $carrierFieldsResolver;
 
-    private static $countriesWithInternalPickupPoints = ['CZ', 'SK', 'HU', 'RO'];
-
     /**
      * CarrierAdminForm constructor.
      *
@@ -439,7 +437,7 @@ class CarrierAdminForm
     private function hasInternalCountry(array $carrierCountries)
     {
         foreach ($carrierCountries as $carrierCountry) {
-            if (in_array($carrierCountry, self::$countriesWithInternalPickupPoints, true)) {
+            if (in_array($carrierCountry, CarrierTools::COUNTRIES_WITH_INTERNAL_PICKUP_POINTS, true)) {
                 return true;
             }
         }

--- a/packetery/libs/Carrier/CarrierTools.php
+++ b/packetery/libs/Carrier/CarrierTools.php
@@ -16,6 +16,14 @@ use CountryCore as Country;
 
 class CarrierTools
 {
+    /** Countries where Packeta has its own pickup points; a claim is posted there. */
+    public const COUNTRIES_WITH_INTERNAL_PICKUP_POINTS = [
+        'CZ',
+        'SK',
+        'HU',
+        'RO',
+    ];
+
     /**
      * Czech and Slovak Home Delivery.
      *

--- a/packetery/libs/Exceptions/ClaimRequestException.php
+++ b/packetery/libs/Exceptions/ClaimRequestException.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @author    Packeta s.r.o. <e-commerce.support@packeta.com>
+ * @copyright 2015-2026 Packeta s.r.o.
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Packetery\Exceptions;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class ClaimRequestException extends \Exception
+{
+    /** @var string */
+    private $faultCode;
+
+    public function __construct(string $faultCode, string $faultString)
+    {
+        parent::__construct($faultString);
+        $this->faultCode = $faultCode;
+    }
+
+    public function getFaultCode(): string
+    {
+        return $this->faultCode;
+    }
+}

--- a/packetery/libs/Log/LogRepository.php
+++ b/packetery/libs/Log/LogRepository.php
@@ -28,6 +28,8 @@ class LogRepository
     public const ACTION_PICKUP_POINT_VALIDATE = 'pickup-point-validate';
     public const ACTION_COLLECTION_PRINT = 'collection-print';
     public const ACTION_PACKET_INFO = 'packet-info';
+    public const ACTION_CLAIM_CREATION = 'claim-creation';
+    public const ACTION_CLAIM_CANCELLING = 'claim-cancelling';
 
     /** @var DbTools */
     private $dbTools;
@@ -77,6 +79,8 @@ class LogRepository
             self::ACTION_PICKUP_POINT_VALIDATE => $this->module->l('Pickup point validation', 'logrepository'),
             self::ACTION_COLLECTION_PRINT => $this->module->l('Print bill of delivery', 'logrepository'),
             self::ACTION_PACKET_INFO => $this->module->l('Packet Info', 'logrepository'),
+            self::ACTION_CLAIM_CREATION => $this->module->l('Return creation', 'logrepository'),
+            self::ACTION_CLAIM_CANCELLING => $this->module->l('Return cancelling', 'logrepository'),
         ];
     }
 

--- a/packetery/libs/Module/Installer.php
+++ b/packetery/libs/Module/Installer.php
@@ -187,10 +187,13 @@ class Installer
             `point_city` varchar(70) NULL,
             `consign_password` varchar(10) NULL,
             `consign_password_processed` datetime NULL,
+            `claim_id` varchar(15) NULL,
+            `claim_password` varchar(10) NULL,
             UNIQUE(`id_order`),
             UNIQUE(`id_cart`),
             KEY `idx_consign_tracking` (`tracking_number`, `consign_password`),
-            KEY `idx_consign_processed` (`consign_password_processed`)
+            KEY `idx_consign_processed` (`consign_password_processed`),
+            KEY `idx_claim_id` (`claim_id`)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8;';
 
         $sql[] = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'packetery_payment`';

--- a/packetery/libs/Module/SoapApi.php
+++ b/packetery/libs/Module/SoapApi.php
@@ -327,6 +327,30 @@ class SoapApi
         return $response;
     }
 
+    public function createPacketClaimWithPassword(
+        Packetery\Request\CreateClaimRequest $request
+    ): Packetery\Response\CreateClaimResponse {
+        $response = new Packetery\Response\CreateClaimResponse();
+
+        try {
+            $soapClient = new \SoapClient($this->resolveWsdlUrl());
+            $result = $soapClient->createPacketClaimWithPassword(
+                $this->configHelper->getApiPass(),
+                $request->getSubmittableData()
+            );
+        } catch (\SoapFault $exception) {
+            $response->setFault($this->getFaultIdentifier($exception));
+            $response->setFaultString($exception->faultstring);
+
+            return $response;
+        }
+
+        $response->setId(isset($result->id) ? (string) $result->id : null);
+        $response->setPassword(isset($result->password) ? (string) $result->password : null);
+
+        return $response;
+    }
+
     public function createShipment(array $packetIds): Packetery\Response\CreateShipmentResponse
     {
         $response = new Packetery\Response\CreateShipmentResponse();

--- a/packetery/libs/Order/ClaimCanceller.php
+++ b/packetery/libs/Order/ClaimCanceller.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * @author    Packeta s.r.o. <e-commerce.support@packeta.com>
+ * @copyright 2015-2026 Packeta s.r.o.
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Packetery\Order;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+use Packetery\Exceptions\DatabaseException;
+use Packetery\Log\LogRepository;
+use Packetery\Module\SoapApi;
+use Packetery\Request\CancelPacketRequest;
+use Packetery\Response\CancelPacketResponse;
+
+/**
+ * Cancels a claim packet via SOAP.
+ * Avoids PacketCanceller (bound to the packet: clears tracking_number/consign_password),
+ * so the order's tracking_number stays unchanged.
+ */
+class ClaimCanceller
+{
+    /** @var SoapApi */
+    private $soapApi;
+    /** @var OrderRepository */
+    private $orderRepository;
+    /** @var LogRepository */
+    private $logRepository;
+
+    public function __construct(
+        SoapApi $soapApi,
+        OrderRepository $orderRepository,
+        LogRepository $logRepository
+    ) {
+        $this->soapApi = $soapApi;
+        $this->orderRepository = $orderRepository;
+        $this->logRepository = $logRepository;
+    }
+
+    /**
+     * Cancels the return in Packeta, then clears the local claim id.
+     * The caller must pass an order with a non-empty claim id (the grid gate guarantees it);
+     * a DB clear failure after a successful cancel is reported as an orphan.
+     *
+     * @throws DatabaseException
+     */
+    public function cancel(int $orderId): CancelPacketResponse
+    {
+        $orderData = $this->orderRepository->getById($orderId);
+        $claimId = is_array($orderData) ? (string) ($orderData['claim_id'] ?? '') : '';
+
+        $response = $this->soapApi->cancelPacket(new CancelPacketRequest($claimId));
+
+        if ($response->hasFault()) {
+            $this->logRepository->insertRow(
+                LogRepository::ACTION_CLAIM_CANCELLING,
+                [
+                    'fault' => $response->getFault(),
+                    'faultString' => $response->getFaultString(),
+                ],
+                LogRepository::STATUS_ERROR,
+                $orderId
+            );
+
+            return $response;
+        }
+
+        // the API cancelled the return; log it before the DB write so the result is never lost
+        $this->logRepository->insertRow(
+            LogRepository::ACTION_CLAIM_CANCELLING,
+            ['packetClaimId' => $claimId],
+            LogRepository::STATUS_SUCCESS,
+            $orderId
+        );
+
+        try {
+            $this->orderRepository->clearClaim($orderId);
+        } catch (DatabaseException $exception) {
+            // the return was cancelled in Packeta but the local write failed; the caller logs the orphan
+            $response->setFault(ClaimFault::CLAIM_NOT_CLEARED);
+            $response->setFaultString("Return {$claimId} was cancelled in Packeta but could not be cleared from the order.");
+        }
+
+        return $response;
+    }
+}

--- a/packetery/libs/Order/ClaimEligibility.php
+++ b/packetery/libs/Order/ClaimEligibility.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * @author    Packeta s.r.o. <e-commerce.support@packeta.com>
+ * @copyright 2015-2026 Packeta s.r.o.
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Packetery\Order;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+use Packetery\Carrier\CarrierTools;
+use Packetery\PacketTracking\PacketStatus;
+
+/**
+ * Pure claim-availability logic (no PrestaShop objects),
+ * used by both the grid icon and the server-side check.
+ */
+class ClaimEligibility
+{
+    public function canCreateClaim(
+        ?string $trackingNumber,
+        ?int $lastStatusCode,
+        ?string $deliveryCountryIso,
+        ?string $existingClaimId
+    ): bool {
+        if ($trackingNumber === null || $trackingNumber === '') {
+            return false;
+        }
+        if ($lastStatusCode !== PacketStatus::DELIVERED) {
+            return false;
+        }
+        if (
+            $deliveryCountryIso === null
+            || !in_array(strtoupper($deliveryCountryIso), CarrierTools::COUNTRIES_WITH_INTERNAL_PICKUP_POINTS, true)
+        ) {
+            return false;
+        }
+
+        return $existingClaimId === null || $existingClaimId === '';
+    }
+
+    public function canCancelClaim(?string $existingClaimId): bool
+    {
+        return $existingClaimId !== null && $existingClaimId !== '';
+    }
+}

--- a/packetery/libs/Order/ClaimFault.php
+++ b/packetery/libs/Order/ClaimFault.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @author    Packeta s.r.o. <e-commerce.support@packeta.com>
+ * @copyright 2015-2026 Packeta s.r.o.
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Packetery\Order;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class ClaimFault
+{
+    public const ORDER_NOT_FOUND = 'orderNotFound';
+    public const ESHOP_ID_MISSING = 'eshopIdMissing';
+    public const VALUE_UNRESOLVED = 'valueUnresolved';
+    public const EMAIL_MISSING = 'emailMissing';
+    public const PHONE_MISSING = 'phoneMissing';
+    public const NO_CLAIM_ID = 'noClaimId';
+    public const CLAIM_NOT_SAVED = 'claimNotSaved';
+    public const CLAIM_NOT_CLEARED = 'claimNotCleared';
+}

--- a/packetery/libs/Order/ClaimRequestFactory.php
+++ b/packetery/libs/Order/ClaimRequestFactory.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * @author    Packeta s.r.o. <e-commerce.support@packeta.com>
+ * @copyright 2015-2026 Packeta s.r.o.
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Packetery\Order;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+use Packetery\Exceptions\ClaimRequestException;
+use Packetery\Request\CreateClaimRequest;
+use Packetery\Tools\ConfigHelper;
+
+/**
+ * Builds the claim request for an order.
+ * PrestaShop object access is kept in create() so buildValidatedRequest() and buildRequest()
+ * stay object-free and unit-testable.
+ */
+class ClaimRequestFactory
+{
+    /** @var OrderRepository */
+    private $orderRepository;
+    /** @var OrderExporter */
+    private $orderExporter;
+    /** @var OrderNumberResolver */
+    private $orderNumberResolver;
+
+    public function __construct(
+        OrderRepository $orderRepository,
+        OrderExporter $orderExporter,
+        OrderNumberResolver $orderNumberResolver
+    ) {
+        $this->orderRepository = $orderRepository;
+        $this->orderExporter = $orderExporter;
+        $this->orderNumberResolver = $orderNumberResolver;
+    }
+
+    /**
+     * Reads the order objects and delegates validation and mapping to buildValidatedRequest
+     *
+     * @throws ClaimRequestException
+     * @throws \Packetery\Exceptions\DatabaseException
+     */
+    public function create(int $orderId): CreateClaimRequest
+    {
+        $psOrder = new \Order($orderId);
+        $packeteryOrder = $this->orderRepository->getOrderWithCountry($orderId);
+
+        $eshopId = (string) ConfigHelper::get(
+            ConfigHelper::KEY_ESHOP_ID,
+            (int) $psOrder->id_shop_group,
+            (int) $psOrder->id_shop
+        );
+
+        // The value is null when the exchange rate for the order currency cannot be resolved
+        [$currency, $value] = is_array($packeteryOrder)
+            ? $this->orderExporter->findCurrencyAndTotalValue($psOrder, $packeteryOrder)
+            : [null, null];
+
+        $customer = $psOrder->getCustomer();
+        $address = new \Address((int) $psOrder->id_address_delivery);
+
+        return $this->buildValidatedRequest(
+            $packeteryOrder,
+            $eshopId,
+            $value,
+            $currency,
+            $this->orderNumberResolver->getPreferredOrderNumber($psOrder),
+            (string) $customer->email,
+            (string) $address->phone_mobile,
+            (string) $address->phone
+        );
+    }
+
+    /**
+     * Validates the resolved order inputs and builds the claim request,
+     * free of PrestaShop objects so the fault paths stay unit-testable
+     *
+     * @param mixed $packeteryOrder repository row (array), or false/null when not found
+     *
+     * @throws ClaimRequestException
+     */
+    public function buildValidatedRequest(
+        $packeteryOrder,
+        string $eshopId,
+        ?float $value,
+        ?string $currency,
+        string $orderNumber,
+        string $email,
+        string $phoneMobile,
+        string $phone
+    ): CreateClaimRequest {
+        if (!is_array($packeteryOrder)) {
+            throw new ClaimRequestException(ClaimFault::ORDER_NOT_FOUND, 'Packetery order not found.');
+        }
+        if ($eshopId === '') {
+            throw new ClaimRequestException(ClaimFault::ESHOP_ID_MISSING, 'Packetery eShop ID is not configured.');
+        }
+        if ($value === null) {
+            throw new ClaimRequestException(ClaimFault::VALUE_UNRESOLVED, 'Order total value could not be resolved.');
+        }
+        if ($email === '') {
+            throw new ClaimRequestException(ClaimFault::EMAIL_MISSING, 'Customer email is missing; the return cannot be created.');
+        }
+        if ($this->resolvePhone($phoneMobile, $phone) === null) {
+            throw new ClaimRequestException(ClaimFault::PHONE_MISSING, 'Customer phone is missing; the return cannot be created.');
+        }
+
+        $consignCountry = (string) ($packeteryOrder['ps_country'] ?? '');
+
+        return $this->buildRequest(
+            $orderNumber,
+            $email,
+            $phoneMobile,
+            $phone,
+            $value,
+            (string) $currency,
+            $eshopId,
+            $consignCountry
+        );
+    }
+
+    /**
+     * Maps the already-resolved order values to the claim request
+     */
+    public function buildRequest(
+        string $orderNumber,
+        string $email,
+        string $phoneMobile,
+        string $phone,
+        float $value,
+        string $currency,
+        string $eshopId,
+        string $consignCountry
+    ): CreateClaimRequest {
+        return new CreateClaimRequest(
+            $orderNumber,
+            $email !== '' ? $email : null,
+            $this->resolvePhone($phoneMobile, $phone),
+            $value,
+            $currency,
+            $eshopId,
+            $consignCountry !== '' ? $consignCountry : null,
+            $email !== '' // notify only when an email is present; buildValidatedRequest already enforces it
+        );
+    }
+
+    private function resolvePhone(string $phoneMobile, string $phone): ?string
+    {
+        if ($phoneMobile !== '') {
+            $resolved = trim($phoneMobile);
+        } else {
+            $resolved = trim($phone);
+        }
+
+        if ($resolved === '') {
+            return null;
+        }
+
+        return $resolved;
+    }
+}

--- a/packetery/libs/Order/ClaimSubmitter.php
+++ b/packetery/libs/Order/ClaimSubmitter.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * @author    Packeta s.r.o. <e-commerce.support@packeta.com>
+ * @copyright 2015-2026 Packeta s.r.o.
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Packetery\Order;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+use Packetery\Exceptions\ClaimRequestException;
+use Packetery\Exceptions\DatabaseException;
+use Packetery\Log\LogRepository;
+use Packetery\Module\SoapApi;
+use Packetery\Response\CreateClaimResponse;
+
+class ClaimSubmitter
+{
+    /** @var ClaimRequestFactory */
+    private $requestFactory;
+    /** @var SoapApi */
+    private $soapApi;
+    /** @var OrderRepository */
+    private $orderRepository;
+    /** @var LogRepository */
+    private $logRepository;
+
+    public function __construct(
+        ClaimRequestFactory $requestFactory,
+        SoapApi $soapApi,
+        OrderRepository $orderRepository,
+        LogRepository $logRepository
+    ) {
+        $this->requestFactory = $requestFactory;
+        $this->soapApi = $soapApi;
+        $this->orderRepository = $orderRepository;
+        $this->logRepository = $logRepository;
+    }
+
+    /**
+     * @throws DatabaseException
+     */
+    public function submit(int $orderId): CreateClaimResponse
+    {
+        try {
+            $request = $this->requestFactory->create($orderId);
+        } catch (ClaimRequestException $exception) {
+            // pre-API validation: the call never reached the API, so this is not an API-log event
+            return $this->buildFaultResponse($exception->getFaultCode(), $exception->getMessage());
+        }
+
+        $response = $this->soapApi->createPacketClaimWithPassword($request);
+
+        if ($response->hasFault()) {
+            $this->logApiError($orderId, $response->getFault(), $response->getFaultString());
+
+            return $response;
+        }
+
+        $claimId = $response->getId();
+        if ($claimId === null) {
+            // the API answered without a return number, which is an API-side error
+            $faultString = 'Packeta API returned a response without a return number.';
+            $this->logApiError($orderId, ClaimFault::NO_CLAIM_ID, $faultString);
+            $response->setFault(ClaimFault::NO_CLAIM_ID);
+            $response->setFaultString($faultString);
+
+            return $response;
+        }
+
+        // the API created the return; log it before the DB write so the number is never lost
+        $this->logRepository->insertRow(
+            LogRepository::ACTION_CLAIM_CREATION,
+            ['packetClaimId' => $claimId],
+            LogRepository::STATUS_SUCCESS,
+            $orderId
+        );
+
+        try {
+            $this->orderRepository->setClaim($orderId, $claimId, $response->getPassword());
+        } catch (DatabaseException $exception) {
+            // the return exists in Packeta but the local write failed; the caller logs the orphan
+            $response->setFault(ClaimFault::CLAIM_NOT_SAVED);
+            $response->setFaultString("Return {$claimId} was created in Packeta but could not be saved to the order.");
+        }
+
+        return $response;
+    }
+
+    private function logApiError(int $orderId, string $fault, string $faultString): void
+    {
+        $this->logRepository->insertRow(
+            LogRepository::ACTION_CLAIM_CREATION,
+            [
+                'fault' => $fault,
+                'faultString' => $faultString,
+            ],
+            LogRepository::STATUS_ERROR,
+            $orderId
+        );
+    }
+
+    private function buildFaultResponse(string $fault, string $faultString): CreateClaimResponse
+    {
+        $response = new CreateClaimResponse();
+        $response->setFault($fault);
+        $response->setFaultString($faultString);
+
+        return $response;
+    }
+}

--- a/packetery/libs/Order/OrderExporter.php
+++ b/packetery/libs/Order/OrderExporter.php
@@ -216,7 +216,7 @@ class OrderExporter
      *
      * @param array<string, mixed> $packeteryOrder data from database
      *
-     * @return array<int, string|float>
+     * @return array{0: string, 1: float|int|null} value is null when the exchange rate is missing
      */
     public function findCurrencyAndTotalValue(\Order $order, array $packeteryOrder): array
     {

--- a/packetery/libs/Order/OrderRepository.php
+++ b/packetery/libs/Order/OrderRepository.php
@@ -229,7 +229,7 @@ class OrderRepository
     /**
      * @param int $orderId
      *
-     * @return array|bool|object|null
+     * @return array|false
      *
      * @throws DatabaseException
      */
@@ -269,6 +269,7 @@ class OrderRepository
                    `po`.`point_city`,
                    `po`.`point_zip`,
                    `po`.`consign_password`,
+                   `po`.`claim_id`,
                    `c`.`iso_code` AS `ps_country`
             FROM `' . _DB_PREFIX_ . 'packetery_order` `po`
             JOIN `' . _DB_PREFIX_ . 'orders` `o` ON `o`.`id_order` = `po`.`id_order`
@@ -281,7 +282,7 @@ class OrderRepository
     /**
      * @param int $orderId
      *
-     * @return array|bool|object|null
+     * @return array|false
      *
      * @throws DatabaseException
      */
@@ -308,7 +309,8 @@ class OrderRepository
                    `zip`,
                    `city`,
                    `street`,
-                   `house_number`
+                   `house_number`,
+                   `claim_id`
             FROM `' . _DB_PREFIX_ . 'packetery_order`
             WHERE `id_order` = ' . $orderId);
     }
@@ -349,7 +351,8 @@ class OrderRepository
                    `zip`,
                    `city`,
                    `street`,
-                   `house_number`
+                   `house_number`,
+                   `claim_id`
             FROM `' . _DB_PREFIX_ . 'packetery_order`
             WHERE `id_order` IN (' . $idList . ')');
 
@@ -635,6 +638,36 @@ class OrderRepository
                 'consign_password_processed' => null,
             ],
             'id_order = ' . $orderId,
+            0,
+            true
+        );
+    }
+
+    public function setClaim(int $orderId, string $claimId, ?string $claimPassword): bool
+    {
+        return $this->dbTools->update(
+            'packetery_order',
+            [
+                'claim_id' => $this->db->escape($claimId),
+                'claim_password' => $claimPassword === null
+                    ? null
+                    : $this->db->escape($claimPassword),
+            ],
+            '`id_order` = ' . $orderId,
+            0,
+            true
+        );
+    }
+
+    public function clearClaim(int $orderId): bool
+    {
+        return $this->dbTools->update(
+            'packetery_order',
+            [
+                'claim_id' => null,
+                'claim_password' => null,
+            ],
+            '`id_order` = ' . $orderId,
             0,
             true
         );

--- a/packetery/libs/Request/CreateClaimRequest.php
+++ b/packetery/libs/Request/CreateClaimRequest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * @author    Packeta s.r.o. <e-commerce.support@packeta.com>
+ * @copyright 2015-2026 Packeta s.r.o.
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Packetery\Request;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class CreateClaimRequest
+{
+    /** @var string */
+    private $number;
+    /** @var string|null */
+    private $email;
+    /** @var string|null */
+    private $phone;
+    /** @var float */
+    private $value;
+    /** @var string */
+    private $currency;
+    /** @var string */
+    private $eshop;
+    /** @var string|null */
+    private $consignCountry;
+    /** @var bool */
+    private $sendEmailToCustomer;
+
+    public function __construct(
+        string $number,
+        ?string $email,
+        ?string $phone,
+        float $value,
+        string $currency,
+        string $eshop,
+        ?string $consignCountry,
+        bool $sendEmailToCustomer = false
+    ) {
+        $this->number = $number;
+        $this->email = $email;
+        $this->phone = $phone;
+        $this->value = $value;
+        $this->currency = $currency;
+        $this->eshop = $eshop;
+        $this->consignCountry = $consignCountry;
+        $this->sendEmailToCustomer = $sendEmailToCustomer;
+    }
+
+    /**
+     * Nulls are sent as empty strings; omitting a WSDL element breaks PHP SoapClient encoding.
+     *
+     * @return array<string, string|float|bool>
+     */
+    public function getSubmittableData(): array
+    {
+        return [
+            'number' => $this->number,
+            'email' => (string) $this->email,
+            'phone' => (string) $this->phone,
+            'value' => $this->value,
+            'currency' => $this->currency,
+            'eshop' => $this->eshop,
+            'consignCountry' => (string) $this->consignCountry,
+            'sendEmailToCustomer' => $this->sendEmailToCustomer,
+        ];
+    }
+}

--- a/packetery/libs/Response/CreateClaimResponse.php
+++ b/packetery/libs/Response/CreateClaimResponse.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @author    Packeta s.r.o. <e-commerce.support@packeta.com>
+ * @copyright 2015-2026 Packeta s.r.o.
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Packetery\Response;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class CreateClaimResponse extends BaseResponse
+{
+    /** @var string|null */
+    private $id;
+
+    /** @var string|null */
+    private $password;
+
+    public function setId(?string $id): void
+    {
+        $this->id = $id;
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function setPassword(?string $password): void
+    {
+        $this->password = $password;
+    }
+
+    public function getPassword(): ?string
+    {
+        return $this->password;
+    }
+}

--- a/packetery/libs/Tools/DbTools.php
+++ b/packetery/libs/Tools/DbTools.php
@@ -180,7 +180,7 @@ class DbTools
     /**
      * @param string $table
      * @param array $data
-     * @param false $nullValues
+     * @param bool $nullValues
      * @param bool $useCache
      * @param int $type
      * @param bool $addPrefix
@@ -207,7 +207,7 @@ class DbTools
      * @param array $data
      * @param string $where
      * @param int $limit
-     * @param false $nullValues
+     * @param bool $nullValues
      * @param bool $useCache
      * @param bool $addPrefix
      *

--- a/packetery/upgrade/upgrade-3.5.0.php
+++ b/packetery/upgrade/upgrade-3.5.0.php
@@ -42,6 +42,11 @@ function upgrade_module_3_5_0(Packetery $module): bool
         ADD KEY `idx_consign_tracking` (`tracking_number`, `consign_password`),
         ADD KEY `idx_consign_processed` (`consign_password_processed`);';
 
+    $sql[] = 'ALTER TABLE `' . _DB_PREFIX_ . 'packetery_order`
+        ADD `claim_id` VARCHAR(15) NULL AFTER `consign_password_processed`,
+        ADD `claim_password` VARCHAR(10) NULL AFTER `claim_id`,
+        ADD KEY `idx_claim_id` (`claim_id`);';
+
     $executeResult = $dbTools->executeQueries(
         $sql,
         $module->l('Exception raised during Packetery module upgrade:', 'upgrade-3.5.0'),

--- a/packetery/views/css/back.css
+++ b/packetery/views/css/back.css
@@ -55,6 +55,10 @@
     white-space: nowrap;
 }
 
+.packeteryordergrid .packetery-claim-line {
+    white-space: nowrap;
+}
+
 .packeteryordergrid thead tr th .title_box {
     white-space: normal !important;
     text-align: left !important;
@@ -62,6 +66,12 @@
 
 .packeteryordergrid .column-weight input {
     padding: 8px;
+}
+
+#table-orders .btn-group.pull-right {
+    display: flex;
+    flex-wrap: nowrap;
+    justify-content: flex-end;
 }
 
 .packeteryloggrid-success {

--- a/packetery/views/js/back.js
+++ b/packetery/views/js/back.js
@@ -95,6 +95,11 @@ $(document).ready(function () {
             event.preventDefault();
         }
     });
+    $('#table-orders').on('click', 'a[data-confirm]', function (event) {
+        if (!confirm($(this).data('confirm'))) {
+            event.preventDefault();
+        }
+    });
 });
 
 //workaround for PS 1.6 BO product detail where PS BO product.js hides the packetery tab because it contains the word pack.

--- a/packetery/views/templates/admin/grid/link.tpl
+++ b/packetery/views/templates/admin/grid/link.tpl
@@ -3,4 +3,4 @@
  * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  *}
 
-<a{if isset($class)} class="{$class|escape:'htmlall':'UTF-8'}"{/if} href="{$linkUrl|escape:'htmlall':'UTF-8'}" data-toggle="tooltip" data-original-title="{$title|escape:'htmlall':'UTF-8'}"><i class="{$icon|escape:'htmlall':'UTF-8'}"></i></a>
+<a{if isset($class)} class="{$class|escape:'htmlall':'UTF-8'}"{/if} href="{$linkUrl|escape:'htmlall':'UTF-8'}"{if isset($confirmMessage) && $confirmMessage} data-confirm="{$confirmMessage|escape:'htmlall':'UTF-8'}"{/if} data-toggle="tooltip" data-original-title="{$title|escape:'htmlall':'UTF-8'}"><i class="{$icon|escape:'htmlall':'UTF-8'}"></i></a>

--- a/packetery/views/templates/admin/trackingLink.tpl
+++ b/packetery/views/templates/admin/trackingLink.tpl
@@ -4,3 +4,6 @@
  *}
 
 <a href="{$trackingUrl|escape:'htmlall':'UTF-8'}" target="_blank">{$trackingNumber|escape:'htmlall':'UTF-8'}</a>
+{if isset($claimNumber) && $claimNumber}
+    <br><span class="packetery-claim-line">{$claimLabel|escape:'htmlall':'UTF-8'} <a href="{$claimUrl|escape:'htmlall':'UTF-8'}" target="_blank">{$claimNumber|escape:'htmlall':'UTF-8'}</a></span>
+{/if}

--- a/phpstan/phpstan-baseline.neon
+++ b/phpstan/phpstan-baseline.neon
@@ -97,18 +97,6 @@ parameters:
 			path: ../packetery/libs/Carrier/CarrierRepository.php
 
 		-
-			message: '#^Parameter \#3 \$nullValues of method Packetery\\Tools\\DbTools\:\:insert\(\) expects false, true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../packetery/libs/Carrier/CarrierRepository.php
-
-		-
-			message: '#^Parameter \#5 \$nullValues of method Packetery\\Tools\\DbTools\:\:update\(\) expects false, true given\.$#'
-			identifier: argument.type
-			count: 2
-			path: ../packetery/libs/Carrier/CarrierRepository.php
-
-		-
 			message: '#^Call to an undefined static method Carrier\:\:getCarrierNameFromShopName\(\)\.$#'
 			identifier: staticMethod.notFound
 			count: 1
@@ -203,30 +191,6 @@ parameters:
 			identifier: booleanNot.exprNotBoolean
 			count: 1
 			path: ../packetery/libs/Order/OrderExporter.php
-
-		-
-			message: '#^Parameter \#3 \$nullValues of method Packetery\\Tools\\DbTools\:\:insert\(\) expects false, bool given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../packetery/libs/Order/OrderRepository.php
-
-		-
-			message: '#^Parameter \#3 \$nullValues of method Packetery\\Tools\\DbTools\:\:insert\(\) expects false, true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../packetery/libs/Order/OrderRepository.php
-
-		-
-			message: '#^Parameter \#5 \$nullValues of method Packetery\\Tools\\DbTools\:\:update\(\) expects false, bool given\.$#'
-			identifier: argument.type
-			count: 2
-			path: ../packetery/libs/Order/OrderRepository.php
-
-		-
-			message: '#^Parameter \#5 \$nullValues of method Packetery\\Tools\\DbTools\:\:update\(\) expects false, true given\.$#'
-			identifier: argument.type
-			count: 4
-			path: ../packetery/libs/Order/OrderRepository.php
 
 		-
 			message: '#^Only booleans are allowed in an if condition, string given\.$#'

--- a/tests/Unit/Order/ClaimCancellerTest.php
+++ b/tests/Unit/Order/ClaimCancellerTest.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * @author    Packeta s.r.o. <e-commerce.support@packeta.com>
+ * @copyright 2015-2026 Packeta s.r.o.
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Packetery\Tests\Unit\Order;
+
+use Packetery\Exceptions\DatabaseException;
+use Packetery\Log\LogRepository;
+use Packetery\Module\SoapApi;
+use Packetery\Order\ClaimCanceller;
+use Packetery\Order\ClaimFault;
+use Packetery\Order\OrderRepository;
+use Packetery\Response\CancelPacketResponse;
+use PHPUnit\Framework\TestCase;
+
+class ClaimCancellerTest extends TestCase
+{
+    private const ORDER_ID = 42;
+    private const CLAIM_ID = 'Z9012';
+
+    public function testCancellingClaimSuccess(): void
+    {
+        $orderRepository = $this->createMock(OrderRepository::class);
+        $orderRepository
+            ->method('getById')
+            ->willReturn(['claim_id' => self::CLAIM_ID]);
+        $orderRepository
+            ->expects($this->once())
+            ->method('clearClaim')
+            ->with(self::ORDER_ID)
+            ->willReturn(true);
+
+        $soapApi = $this->createStub(SoapApi::class);
+        $soapApi
+            ->method('cancelPacket')
+            ->willReturn(new CancelPacketResponse());
+
+        $logRepository = $this->createMock(LogRepository::class);
+        $logRepository
+            ->expects($this->once())
+            ->method('insertRow')
+            ->with(
+                LogRepository::ACTION_CLAIM_CANCELLING,
+                ['packetClaimId' => self::CLAIM_ID],
+                LogRepository::STATUS_SUCCESS,
+                self::ORDER_ID
+            );
+
+        $canceller = new ClaimCanceller($soapApi, $orderRepository, $logRepository);
+        $response = $canceller->cancel(self::ORDER_ID);
+
+        $this->assertFalse($response->hasFault());
+    }
+
+    public function testCancellingClaimClearFailure(): void
+    {
+        $orderRepository = $this->createStub(OrderRepository::class);
+        $orderRepository
+            ->method('getById')
+            ->willReturn(['claim_id' => self::CLAIM_ID]);
+        $orderRepository
+            ->method('clearClaim')
+            ->willThrowException(new DatabaseException('write failed'));
+
+        $soapApi = $this->createStub(SoapApi::class);
+        $soapApi
+            ->method('cancelPacket')
+            ->willReturn(new CancelPacketResponse());
+
+        // the API cancelled the return, so it is logged before the failing DB clear
+        $logRepository = $this->createMock(LogRepository::class);
+        $logRepository
+            ->expects($this->once())
+            ->method('insertRow')
+            ->with(
+                LogRepository::ACTION_CLAIM_CANCELLING,
+                ['packetClaimId' => self::CLAIM_ID],
+                LogRepository::STATUS_SUCCESS,
+                self::ORDER_ID
+            );
+
+        $canceller = new ClaimCanceller($soapApi, $orderRepository, $logRepository);
+        $response = $canceller->cancel(self::ORDER_ID);
+
+        $this->assertTrue($response->hasFault());
+        $this->assertSame(ClaimFault::CLAIM_NOT_CLEARED, $response->getFault());
+        $this->assertSame(
+            'Return ' . self::CLAIM_ID . ' was cancelled in Packeta but could not be cleared from the order.',
+            $response->getFaultString()
+        );
+    }
+
+    public function testCancellingClaimApiFault(): void
+    {
+        $faultyResponse = new CancelPacketResponse();
+        $faultyResponse->setFault('PacketIdFault');
+        $faultyResponse->setFaultString('Unknown packet.');
+
+        $orderRepository = $this->createMock(OrderRepository::class);
+        $orderRepository
+            ->method('getById')
+            ->willReturn(['claim_id' => self::CLAIM_ID]);
+        $orderRepository
+            ->expects($this->never())
+            ->method('clearClaim');
+
+        $soapApi = $this->createStub(SoapApi::class);
+        $soapApi
+            ->method('cancelPacket')
+            ->willReturn($faultyResponse);
+
+        $logRepository = $this->createMock(LogRepository::class);
+        $logRepository
+            ->expects($this->once())
+            ->method('insertRow')
+            ->with(
+                LogRepository::ACTION_CLAIM_CANCELLING,
+                [
+                    'fault' => 'PacketIdFault',
+                    'faultString' => 'Unknown packet.',
+                ],
+                LogRepository::STATUS_ERROR,
+                self::ORDER_ID
+            );
+
+        $canceller = new ClaimCanceller($soapApi, $orderRepository, $logRepository);
+        $response = $canceller->cancel(self::ORDER_ID);
+
+        $this->assertTrue($response->hasFault());
+    }
+}

--- a/tests/Unit/Order/ClaimEligibilityTest.php
+++ b/tests/Unit/Order/ClaimEligibilityTest.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * @author    Packeta s.r.o. <e-commerce.support@packeta.com>
+ * @copyright 2015-2026 Packeta s.r.o.
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Packetery\Tests\Unit\Order;
+
+use Packetery\Order\ClaimEligibility;
+use Packetery\PacketTracking\PacketStatus;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class ClaimEligibilityTest extends TestCase
+{
+    #[DataProvider('createClaimProvider')]
+    public function testCreateClaimAvailability(
+        ?string $trackingNumber,
+        ?int $lastStatusCode,
+        ?string $deliveryCountryIso,
+        ?string $existingClaimId,
+        bool $expected
+    ): void {
+        $eligibility = new ClaimEligibility();
+
+        $this->assertSame(
+            $expected,
+            $eligibility->canCreateClaim(
+                $trackingNumber,
+                $lastStatusCode,
+                $deliveryCountryIso,
+                $existingClaimId
+            )
+        );
+    }
+
+    /**
+     * @return array<string, array{?string, ?int, ?string, ?string, bool}>
+     */
+    public static function createClaimProvider(): array
+    {
+        return [
+            'offered: delivered to a pickup-point country, no claim yet' => [
+                'Z123',
+                PacketStatus::DELIVERED,
+                'CZ',
+                null,
+                true,
+            ],
+            'offered: pickup-point country matched case-insensitively' => [
+                'Z123',
+                PacketStatus::DELIVERED,
+                'sk',
+                null,
+                true,
+            ],
+            'offered: delivered to HU' => [
+                'Z123',
+                PacketStatus::DELIVERED,
+                'HU',
+                null,
+                true,
+            ],
+            'offered: delivered to RO' => [
+                'Z123',
+                PacketStatus::DELIVERED,
+                'RO',
+                null,
+                true,
+            ],
+            'offered: empty stored claim treated as none' => [
+                'Z123',
+                PacketStatus::DELIVERED,
+                'CZ',
+                '',
+                true,
+            ],
+            'hidden: parcel not submitted (no tracking number)' => [
+                null,
+                PacketStatus::DELIVERED,
+                'CZ',
+                null,
+                false,
+            ],
+            'hidden: parcel not submitted (empty tracking number)' => [
+                '',
+                PacketStatus::DELIVERED,
+                'CZ',
+                null,
+                false,
+            ],
+            'hidden: parcel not yet delivered' => [
+                'Z123',
+                PacketStatus::RECEIVED_DATA,
+                'CZ',
+                null,
+                false,
+            ],
+            'hidden: packet status unknown' => [
+                'Z123',
+                null,
+                'CZ',
+                null,
+                false,
+            ],
+            'hidden: delivery country has no pickup points' => [
+                'Z123',
+                PacketStatus::DELIVERED,
+                'DE',
+                null,
+                false,
+            ],
+            'hidden: delivery country missing' => [
+                'Z123',
+                PacketStatus::DELIVERED,
+                null,
+                null,
+                false,
+            ],
+            'hidden: a claim was already created' => [
+                'Z123',
+                PacketStatus::DELIVERED,
+                'CZ',
+                'Z999',
+                false,
+            ],
+        ];
+    }
+
+    #[DataProvider('cancelClaimProvider')]
+    public function testCancelClaimAvailability(?string $existingClaimId, bool $expected): void
+    {
+        $eligibility = new ClaimEligibility();
+
+        $this->assertSame($expected, $eligibility->canCancelClaim($existingClaimId));
+    }
+
+    /**
+     * @return array<string, array{?string, bool}>
+     */
+    public static function cancelClaimProvider(): array
+    {
+        return [
+            'cancel offered: a claim exists' => ['Z999', true],
+            'cancel hidden: no claim (null)' => [null, false],
+            'cancel hidden: no claim (empty string)' => ['', false],
+        ];
+    }
+}

--- a/tests/Unit/Order/ClaimRequestFactoryTest.php
+++ b/tests/Unit/Order/ClaimRequestFactoryTest.php
@@ -1,0 +1,391 @@
+<?php
+/**
+ * @author    Packeta s.r.o. <e-commerce.support@packeta.com>
+ * @copyright 2015-2026 Packeta s.r.o.
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Packetery\Tests\Unit\Order;
+
+use Packetery\Exceptions\ClaimRequestException;
+use Packetery\Order\ClaimFault;
+use Packetery\Order\ClaimRequestFactory;
+use Packetery\Order\OrderExporter;
+use Packetery\Order\OrderNumberResolver;
+use Packetery\Order\OrderRepository;
+use Packetery\Tools\ConfigHelper;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class ClaimRequestFactoryTest extends TestCase
+{
+    private const ORDER_ID = 42;
+    private const ADDRESS_ID = 7;
+    private const ORDER_NUMBER = 'ORD-15';
+    private const VALUE = 12.5;
+    private const CURRENCY = 'CZK';
+    private const ESHOP_ID = 'muj-eshop.cz';
+    private const COUNTRY = 'CZ';
+    private const EMAIL = 'buyer@example.com';
+    private const PHONE_MOBILE = '732111222';
+    private const PHONE_LANDLINE = '571000000';
+
+    protected function tearDown(): void
+    {
+        \Order::reset();
+        \Address::reset();
+        \Configuration::reset();
+        parent::tearDown();
+    }
+
+    #[DataProvider('providePhoneFallback')]
+    public function testBuildRequestResolvesPhone(string $phoneMobile, string $phone, string $expectedPhone): void
+    {
+        $data = $this->factory()
+            ->buildRequest(
+                self::ORDER_NUMBER,
+                'buyer@example.com',
+                $phoneMobile,
+                $phone,
+                self::VALUE,
+                self::CURRENCY,
+                self::ESHOP_ID,
+                self::COUNTRY
+            )
+            ->getSubmittableData();
+
+        $this->assertSame($expectedPhone, $data['phone']);
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public static function providePhoneFallback(): array
+    {
+        return [
+            'mobile preferred over landline' => ['732111222', '571000000', '732111222'],
+            'falls back to landline when mobile empty' => ['', '571000000', '571000000'],
+            'mobile is trimmed' => ['  732111222  ', '', '732111222'],
+            'whitespace-only mobile does not fall back' => ['   ', '571000000', ''],
+            'both empty yields empty wire value' => ['', '', ''],
+        ];
+    }
+
+    #[DataProvider('provideEmailAndCountry')]
+    public function testBuildRequestMapsEmailAndCountry(
+        string $email,
+        string $country,
+        string $expectedEmail,
+        string $expectedCountry
+    ): void {
+        $data = $this->factory()
+            ->buildRequest(
+                self::ORDER_NUMBER,
+                $email,
+                '732111222',
+                '',
+                self::VALUE,
+                self::CURRENCY,
+                self::ESHOP_ID,
+                $country
+            )
+            ->getSubmittableData();
+
+        $this->assertSame($expectedEmail, $data['email']);
+        $this->assertSame($expectedCountry, $data['consignCountry']);
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string, 3: string}>
+     */
+    public static function provideEmailAndCountry(): array
+    {
+        return [
+            'empty email and country become empty wire values' => [
+                '',
+                '',
+                '',
+                '',
+            ],
+            'provided email and country are kept' => [
+                'buyer@example.com',
+                self::COUNTRY,
+                'buyer@example.com',
+                self::COUNTRY,
+            ],
+        ];
+    }
+
+    public function testBuildRequestMapsScalars(): void
+    {
+        $data = $this->factory()
+            ->buildRequest(
+                self::ORDER_NUMBER,
+                'buyer@example.com',
+                '732111222',
+                '',
+                self::VALUE,
+                self::CURRENCY,
+                self::ESHOP_ID,
+                self::COUNTRY
+            )
+            ->getSubmittableData();
+
+        $this->assertSame(self::ORDER_NUMBER, $data['number']);
+        $this->assertSame(self::VALUE, $data['value']);
+        $this->assertSame(self::CURRENCY, $data['currency']);
+        $this->assertSame(self::ESHOP_ID, $data['eshop']);
+    }
+
+    #[DataProvider('provideEmailFlag')]
+    public function testBuildRequestSetsEmailFlagFromEmailPresence(string $email, bool $expectedFlag): void
+    {
+        $data = $this->factory()
+            ->buildRequest(
+                self::ORDER_NUMBER,
+                $email,
+                '732111222',
+                '',
+                self::VALUE,
+                self::CURRENCY,
+                self::ESHOP_ID,
+                self::COUNTRY
+            )
+            ->getSubmittableData();
+
+        $this->assertSame($expectedFlag, $data['sendEmailToCustomer']);
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: bool}>
+     */
+    public static function provideEmailFlag(): array
+    {
+        return [
+            'email present → notify' => ['buyer@example.com', true],
+            'no email → do not notify' => ['', false],
+        ];
+    }
+
+    /**
+     * @param mixed $packeteryOrder
+     */
+    #[DataProvider('provideInsufficientOrderData')]
+    public function testBuildValidatedRequestRejectsInsufficientOrderData(
+        $packeteryOrder,
+        string $eshopId,
+        ?float $value,
+        string $expectedFault
+    ): void {
+        try {
+            $this->factory()
+                ->buildValidatedRequest(
+                    $packeteryOrder,
+                    $eshopId,
+                    $value,
+                    self::CURRENCY,
+                    self::ORDER_NUMBER,
+                    'buyer@example.com',
+                    '732111222',
+                    ''
+                );
+            $this->fail('Expected ClaimRequestException was not thrown.');
+        } catch (ClaimRequestException $exception) {
+            $this->assertSame($expectedFault, $exception->getFaultCode());
+        }
+    }
+
+    /**
+     * @return array<string, array{0: mixed, 1: string, 2: ?float, 3: string}>
+     */
+    public static function provideInsufficientOrderData(): array
+    {
+        return [
+            'packetery order not found (null)' => [
+                null,
+                self::ESHOP_ID,
+                self::VALUE,
+                ClaimFault::ORDER_NOT_FOUND,
+            ],
+            'packetery order not found (non-array)' => [
+                'nope',
+                self::ESHOP_ID,
+                self::VALUE,
+                ClaimFault::ORDER_NOT_FOUND,
+            ],
+            'eshop id missing' => [
+                ['ps_country' => self::COUNTRY],
+                '',
+                self::VALUE,
+                ClaimFault::ESHOP_ID_MISSING,
+            ],
+            'order value unresolved' => [
+                ['ps_country' => self::COUNTRY],
+                self::ESHOP_ID,
+                null,
+                ClaimFault::VALUE_UNRESOLVED,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideMissingContact')]
+    public function testBuildValidatedRequestRejectsMissingContact(
+        string $email,
+        string $phoneMobile,
+        string $phone,
+        string $expectedFault
+    ): void {
+        try {
+            $this->factory()
+                ->buildValidatedRequest(
+                    ['ps_country' => self::COUNTRY],
+                    self::ESHOP_ID,
+                    self::VALUE,
+                    self::CURRENCY,
+                    self::ORDER_NUMBER,
+                    $email,
+                    $phoneMobile,
+                    $phone
+                );
+            $this->fail('Expected ClaimRequestException was not thrown.');
+        } catch (ClaimRequestException $exception) {
+            $this->assertSame($expectedFault, $exception->getFaultCode());
+        }
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string, 3: string}>
+     */
+    public static function provideMissingContact(): array
+    {
+        return [
+            'missing email' => [
+                '',
+                self::PHONE_MOBILE,
+                '',
+                ClaimFault::EMAIL_MISSING,
+            ],
+            'both missing → email reported first' => [
+                '',
+                '',
+                '',
+                ClaimFault::EMAIL_MISSING,
+            ],
+            'missing phone (both empty)' => [
+                self::EMAIL,
+                '',
+                '',
+                ClaimFault::PHONE_MISSING,
+            ],
+            'whitespace-only phone' => [
+                self::EMAIL,
+                '   ',
+                '   ',
+                ClaimFault::PHONE_MISSING,
+            ],
+        ];
+    }
+
+    public function testBuildValidatedRequestBuildsRequestFromResolvedInputs(): void
+    {
+        $data = $this->factory()
+            ->buildValidatedRequest(
+                ['ps_country' => self::COUNTRY],
+                self::ESHOP_ID,
+                self::VALUE,
+                self::CURRENCY,
+                self::ORDER_NUMBER,
+                'buyer@example.com',
+                '732111222',
+                ''
+            )
+            ->getSubmittableData();
+
+        $this->assertSame(self::ORDER_NUMBER, $data['number']);
+        $this->assertSame(self::VALUE, $data['value']);
+        $this->assertSame(self::CURRENCY, $data['currency']);
+        $this->assertSame(self::ESHOP_ID, $data['eshop']);
+        $this->assertSame(self::COUNTRY, $data['consignCountry']);
+    }
+
+    public function testCreateMapsOrderObjectsToRequest(): void
+    {
+        \Configuration::set(ConfigHelper::KEY_ESHOP_ID, self::ESHOP_ID);
+        \Order::loadFixture(
+            self::ORDER_ID,
+            [
+                'id_shop_group' => 1,
+                'id_shop' => 1,
+                'id_address_delivery' => self::ADDRESS_ID,
+                'customer' => new \Customer(self::EMAIL),
+            ]
+        );
+        \Address::loadFixture(
+            self::ADDRESS_ID,
+            [
+                'phone_mobile' => self::PHONE_MOBILE,
+                'phone' => self::PHONE_LANDLINE,
+            ]
+        );
+
+        $orderRepository = $this->createStub(OrderRepository::class);
+        $orderRepository
+            ->method('getOrderWithCountry')
+            ->willReturn(['ps_country' => self::COUNTRY]);
+
+        $orderExporter = $this->createStub(OrderExporter::class);
+        $orderExporter
+            ->method('findCurrencyAndTotalValue')
+            ->willReturn([self::CURRENCY, self::VALUE]);
+
+        $orderNumberResolver = $this->createStub(OrderNumberResolver::class);
+        $orderNumberResolver
+            ->method('getPreferredOrderNumber')
+            ->willReturn(self::ORDER_NUMBER);
+
+        $data = (new ClaimRequestFactory($orderRepository, $orderExporter, $orderNumberResolver))
+            ->create(self::ORDER_ID)
+            ->getSubmittableData();
+
+        $this->assertSame(self::ORDER_NUMBER, $data['number']);
+        $this->assertSame(self::EMAIL, $data['email']);
+        $this->assertSame(self::PHONE_MOBILE, $data['phone']);
+        $this->assertSame(self::VALUE, $data['value']);
+        $this->assertSame(self::CURRENCY, $data['currency']);
+        $this->assertSame(self::ESHOP_ID, $data['eshop']);
+        $this->assertSame(self::COUNTRY, $data['consignCountry']);
+    }
+
+    public function testCreateRejectsOrderWithoutPacketeryRecord(): void
+    {
+        \Order::loadFixture(self::ORDER_ID, ['id_address_delivery' => self::ADDRESS_ID]);
+
+        $orderRepository = $this->createStub(OrderRepository::class);
+        $orderRepository
+            ->method('getOrderWithCountry')
+            ->willReturn(false);
+
+        $orderExporter = $this->createMock(OrderExporter::class);
+        $orderExporter
+            ->expects($this->never())
+            ->method('findCurrencyAndTotalValue');
+
+        try {
+            (new ClaimRequestFactory($orderRepository, $orderExporter, $this->createStub(OrderNumberResolver::class)))
+                ->create(self::ORDER_ID);
+            $this->fail('Expected ClaimRequestException was not thrown.');
+        } catch (ClaimRequestException $exception) {
+            $this->assertSame(ClaimFault::ORDER_NOT_FOUND, $exception->getFaultCode());
+        }
+    }
+
+    private function factory(): ClaimRequestFactory
+    {
+        return new ClaimRequestFactory(
+            $this->createStub(OrderRepository::class),
+            $this->createStub(OrderExporter::class),
+            $this->createStub(OrderNumberResolver::class)
+        );
+    }
+}

--- a/tests/Unit/Order/ClaimSubmitterTest.php
+++ b/tests/Unit/Order/ClaimSubmitterTest.php
@@ -1,0 +1,247 @@
+<?php
+/**
+ * @author    Packeta s.r.o. <e-commerce.support@packeta.com>
+ * @copyright 2015-2026 Packeta s.r.o.
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Packetery\Tests\Unit\Order;
+
+use Packetery\Exceptions\ClaimRequestException;
+use Packetery\Exceptions\DatabaseException;
+use Packetery\Log\LogRepository;
+use Packetery\Module\SoapApi;
+use Packetery\Order\ClaimFault;
+use Packetery\Order\ClaimRequestFactory;
+use Packetery\Order\ClaimSubmitter;
+use Packetery\Order\OrderRepository;
+use Packetery\Request\CreateClaimRequest;
+use Packetery\Response\CreateClaimResponse;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class ClaimSubmitterTest extends TestCase
+{
+    private const ORDER_ID = 42;
+    private const CLAIM_ID = 'Z9012';
+    private const CLAIM_PASSWORD = 'secret';
+
+    #[DataProvider('provideIncompleteOrderData')]
+    public function testCreatingClaimIncompleteOrder(string $fault, string $faultString): void
+    {
+        $requestFactory = $this->createStub(ClaimRequestFactory::class);
+        $requestFactory
+            ->method('create')
+            ->willThrowException(new ClaimRequestException($fault, $faultString));
+
+        $soapApi = $this->createMock(SoapApi::class);
+        $soapApi
+            ->expects($this->never())
+            ->method('createPacketClaimWithPassword');
+
+        $orderRepository = $this->createMock(OrderRepository::class);
+        $orderRepository
+            ->expects($this->never())
+            ->method('setClaim');
+
+        // pre-API validation never reaches the API, so it must not be written to the API log
+        $logRepository = $this->createMock(LogRepository::class);
+        $logRepository
+            ->expects($this->never())
+            ->method('insertRow');
+
+        $response = $this->createSubmitter($requestFactory, $soapApi, $orderRepository, $logRepository)
+            ->submit(self::ORDER_ID);
+
+        $this->assertTrue($response->hasFault());
+        $this->assertSame($fault, $response->getFault());
+        $this->assertSame($faultString, $response->getFaultString());
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function provideIncompleteOrderData(): array
+    {
+        return [
+            'order not found' => [ClaimFault::ORDER_NOT_FOUND, 'Packetery order not found.'],
+            'eshop id missing' => [ClaimFault::ESHOP_ID_MISSING, 'Packetery eShop ID is not configured.'],
+            'order value unresolved' => [ClaimFault::VALUE_UNRESOLVED, 'Order total value could not be resolved.'],
+            'email missing' => [ClaimFault::EMAIL_MISSING, 'Customer email is missing; the return cannot be created.'],
+            'phone missing' => [ClaimFault::PHONE_MISSING, 'Customer phone is missing; the return cannot be created.'],
+        ];
+    }
+
+    public function testCreatingClaimApiFault(): void
+    {
+        $faultyResponse = new CreateClaimResponse();
+        $faultyResponse->setFault('PacketAttributesFault');
+        $faultyResponse->setFaultString('Invalid value.');
+
+        $requestFactory = $this->createStub(ClaimRequestFactory::class);
+        $requestFactory
+            ->method('create')
+            ->willReturn($this->createStub(CreateClaimRequest::class));
+
+        $soapApi = $this->createStub(SoapApi::class);
+        $soapApi
+            ->method('createPacketClaimWithPassword')
+            ->willReturn($faultyResponse);
+
+        $orderRepository = $this->createMock(OrderRepository::class);
+        $orderRepository
+            ->expects($this->never())
+            ->method('setClaim');
+
+        $logRepository = $this->createMock(LogRepository::class);
+        $logRepository
+            ->expects($this->once())
+            ->method('insertRow')
+            ->with(
+                LogRepository::ACTION_CLAIM_CREATION,
+                [
+                    'fault' => 'PacketAttributesFault',
+                    'faultString' => 'Invalid value.',
+                ],
+                LogRepository::STATUS_ERROR,
+                self::ORDER_ID
+            );
+
+        $response = $this->createSubmitter($requestFactory, $soapApi, $orderRepository, $logRepository)
+            ->submit(self::ORDER_ID);
+
+        $this->assertTrue($response->hasFault());
+    }
+
+    public function testCreatingClaimMissingClaimId(): void
+    {
+        $requestFactory = $this->createStub(ClaimRequestFactory::class);
+        $requestFactory
+            ->method('create')
+            ->willReturn($this->createStub(CreateClaimRequest::class));
+
+        $soapApi = $this->createStub(SoapApi::class);
+        $soapApi
+            ->method('createPacketClaimWithPassword')
+            ->willReturn(new CreateClaimResponse());
+
+        $orderRepository = $this->createMock(OrderRepository::class);
+        $orderRepository
+            ->expects($this->never())
+            ->method('setClaim');
+
+        $logRepository = $this->createMock(LogRepository::class);
+        $logRepository
+            ->expects($this->once())
+            ->method('insertRow')
+            ->with(
+                LogRepository::ACTION_CLAIM_CREATION,
+                [
+                    'fault' => ClaimFault::NO_CLAIM_ID,
+                    'faultString' => 'Packeta API returned a response without a return number.',
+                ],
+                LogRepository::STATUS_ERROR,
+                self::ORDER_ID
+            );
+
+        $response = $this->createSubmitter($requestFactory, $soapApi, $orderRepository, $logRepository)
+            ->submit(self::ORDER_ID);
+
+        $this->assertTrue($response->hasFault());
+        $this->assertSame(ClaimFault::NO_CLAIM_ID, $response->getFault());
+    }
+
+    public function testCreatingClaimSuccess(): void
+    {
+        $successResponse = new CreateClaimResponse();
+        $successResponse->setId(self::CLAIM_ID);
+        $successResponse->setPassword(self::CLAIM_PASSWORD);
+
+        $requestFactory = $this->createStub(ClaimRequestFactory::class);
+        $requestFactory
+            ->method('create')
+            ->willReturn($this->createStub(CreateClaimRequest::class));
+
+        $soapApi = $this->createStub(SoapApi::class);
+        $soapApi
+            ->method('createPacketClaimWithPassword')
+            ->willReturn($successResponse);
+
+        $orderRepository = $this->createMock(OrderRepository::class);
+        $orderRepository
+            ->expects($this->once())
+            ->method('setClaim')
+            ->with(self::ORDER_ID, self::CLAIM_ID, self::CLAIM_PASSWORD)
+            ->willReturn(true);
+
+        $logRepository = $this->createMock(LogRepository::class);
+        $logRepository
+            ->expects($this->once())
+            ->method('insertRow')
+            ->with(
+                LogRepository::ACTION_CLAIM_CREATION,
+                ['packetClaimId' => self::CLAIM_ID],
+                LogRepository::STATUS_SUCCESS,
+                self::ORDER_ID
+            );
+
+        $response = $this->createSubmitter($requestFactory, $soapApi, $orderRepository, $logRepository)
+            ->submit(self::ORDER_ID);
+
+        $this->assertFalse($response->hasFault());
+    }
+
+    public function testCreatingClaimPersistFailure(): void
+    {
+        $successResponse = new CreateClaimResponse();
+        $successResponse->setId(self::CLAIM_ID);
+        $successResponse->setPassword(self::CLAIM_PASSWORD);
+
+        $requestFactory = $this->createStub(ClaimRequestFactory::class);
+        $requestFactory
+            ->method('create')
+            ->willReturn($this->createStub(CreateClaimRequest::class));
+
+        $soapApi = $this->createStub(SoapApi::class);
+        $soapApi
+            ->method('createPacketClaimWithPassword')
+            ->willReturn($successResponse);
+
+        $orderRepository = $this->createStub(OrderRepository::class);
+        $orderRepository
+            ->method('setClaim')
+            ->willThrowException(new DatabaseException('write failed'));
+
+        // the API created the return, so its number is logged before the failing DB write
+        $logRepository = $this->createMock(LogRepository::class);
+        $logRepository
+            ->expects($this->once())
+            ->method('insertRow')
+            ->with(
+                LogRepository::ACTION_CLAIM_CREATION,
+                ['packetClaimId' => self::CLAIM_ID],
+                LogRepository::STATUS_SUCCESS,
+                self::ORDER_ID
+            );
+
+        $response = $this->createSubmitter($requestFactory, $soapApi, $orderRepository, $logRepository)
+            ->submit(self::ORDER_ID);
+
+        $this->assertTrue($response->hasFault());
+        $this->assertSame(ClaimFault::CLAIM_NOT_SAVED, $response->getFault());
+        $this->assertSame(
+            'Return ' . self::CLAIM_ID . ' was created in Packeta but could not be saved to the order.',
+            $response->getFaultString()
+        );
+    }
+
+    private function createSubmitter(
+        ClaimRequestFactory $requestFactory,
+        SoapApi $soapApi,
+        OrderRepository $orderRepository,
+        LogRepository $logRepository
+    ): ClaimSubmitter {
+        return new ClaimSubmitter($requestFactory, $soapApi, $orderRepository, $logRepository);
+    }
+}

--- a/tests/Unit/Request/CreateClaimRequestTest.php
+++ b/tests/Unit/Request/CreateClaimRequestTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @author    Packeta s.r.o. <e-commerce.support@packeta.com>
+ * @copyright 2015-2026 Packeta s.r.o.
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Packetery\Tests\Unit\Request;
+
+use Packetery\Request\CreateClaimRequest;
+use PHPUnit\Framework\TestCase;
+
+class CreateClaimRequestTest extends TestCase
+{
+    public function testGetSubmittableDataMapsAllFields(): void
+    {
+        $request = new CreateClaimRequest(
+            'REF123',
+            'customer@example.com',
+            '+420777123456',
+            1234.5,
+            'CZK',
+            'muj-eshop.cz',
+            'CZ',
+            true
+        );
+
+        $this->assertSame(
+            [
+                'number' => 'REF123',
+                'email' => 'customer@example.com',
+                'phone' => '+420777123456',
+                'value' => 1234.5,
+                'currency' => 'CZK',
+                'eshop' => 'muj-eshop.cz',
+                'consignCountry' => 'CZ',
+                'sendEmailToCustomer' => true,
+            ],
+            $request->getSubmittableData()
+        );
+    }
+
+    public function testGetSubmittableDataConvertsNullablesToEmptyStrings(): void
+    {
+        $request = new CreateClaimRequest(
+            'REF123',
+            null,
+            null,
+            0.0,
+            'CZK',
+            'muj-eshop.cz',
+            null,
+            false
+        );
+
+        $data = $request->getSubmittableData();
+
+        $this->assertSame('', $data['email']);
+        $this->assertSame('', $data['phone']);
+        $this->assertSame('', $data['consignCountry']);
+        $this->assertFalse($data['sendEmailToCustomer']);
+    }
+}

--- a/tests/Unit/Response/CreateClaimResponseTest.php
+++ b/tests/Unit/Response/CreateClaimResponseTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @author    Packeta s.r.o. <e-commerce.support@packeta.com>
+ * @copyright 2015-2026 Packeta s.r.o.
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Packetery\Tests\Unit\Response;
+
+use Packetery\Response\CreateClaimResponse;
+use PHPUnit\Framework\TestCase;
+
+class CreateClaimResponseTest extends TestCase
+{
+    public function testFreshResponseHasNoIdPasswordOrFault(): void
+    {
+        $response = new CreateClaimResponse();
+
+        $this->assertNull($response->getId());
+        $this->assertNull($response->getPassword());
+        $this->assertFalse($response->hasFault());
+    }
+
+    public function testHoldsClaimIdAndPassword(): void
+    {
+        $response = new CreateClaimResponse();
+        $response->setId('Z9012');
+        $response->setPassword('abcd1234');
+
+        $this->assertSame('Z9012', $response->getId());
+        $this->assertSame('abcd1234', $response->getPassword());
+        $this->assertFalse($response->hasFault());
+    }
+
+    public function testFaultIsReportedAndKeepsIdNull(): void
+    {
+        $response = new CreateClaimResponse();
+        $response->setFault('PacketAttributesFault');
+        $response->setFaultString('Email is required.');
+
+        $this->assertTrue($response->hasFault());
+        $this->assertSame('PacketAttributesFault', $response->getFault());
+        $this->assertSame('Email is required.', $response->getFaultString());
+        $this->assertNull($response->getId());
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -16,3 +16,6 @@ require __DIR__ . '/../vendor/autoload.php';
 require __DIR__ . '/../packetery/autoload.php';
 require __DIR__ . '/stubs/Configuration.php';
 require __DIR__ . '/stubs/Packetery.php';
+require __DIR__ . '/stubs/Customer.php';
+require __DIR__ . '/stubs/Address.php';
+require __DIR__ . '/stubs/Order.php';

--- a/tests/stubs/Address.php
+++ b/tests/stubs/Address.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @author    Packeta s.r.o. <e-commerce.support@packeta.com>
+ * @copyright 2015-2026 Packeta s.r.o.
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+declare(strict_types=1);
+
+class Address
+{
+    /** @var array<int, array<string, mixed>> */
+    private static array $fixtures = [];
+
+    /** @var string */
+    public $phone_mobile = '';
+    /** @var string */
+    public $phone = '';
+
+    public function __construct($idAddress = null)
+    {
+        $data = self::$fixtures[(int) $idAddress] ?? [];
+
+        $this->phone_mobile = $data['phone_mobile'] ?? '';
+        $this->phone = $data['phone'] ?? '';
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function loadFixture(int $idAddress, array $data): void
+    {
+        self::$fixtures[$idAddress] = $data;
+    }
+
+    public static function reset(): void
+    {
+        self::$fixtures = [];
+    }
+}

--- a/tests/stubs/Customer.php
+++ b/tests/stubs/Customer.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @author    Packeta s.r.o. <e-commerce.support@packeta.com>
+ * @copyright 2015-2026 Packeta s.r.o.
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+declare(strict_types=1);
+
+class Customer
+{
+    /** @var string */
+    public $email = '';
+
+    public function __construct(string $email = '')
+    {
+        $this->email = $email;
+    }
+}

--- a/tests/stubs/Order.php
+++ b/tests/stubs/Order.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @author    Packeta s.r.o. <e-commerce.support@packeta.com>
+ * @copyright 2015-2026 Packeta s.r.o.
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+declare(strict_types=1);
+
+class Order
+{
+    /** @var array<int, array<string, mixed>> */
+    private static array $fixtures = [];
+
+    /** @var int */
+    public $id_shop_group = 0;
+    /** @var int */
+    public $id_shop = 0;
+    /** @var int */
+    public $id_address_delivery = 0;
+
+    /** @var Customer|null */
+    private $customer;
+
+    public function __construct($orderId = null)
+    {
+        $data = self::$fixtures[(int) $orderId] ?? [];
+
+        $this->id_shop_group = $data['id_shop_group'] ?? 0;
+        $this->id_shop = $data['id_shop'] ?? 0;
+        $this->id_address_delivery = $data['id_address_delivery'] ?? 0;
+        $this->customer = $data['customer'] ?? null;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function loadFixture(int $orderId, array $data): void
+    {
+        self::$fixtures[$orderId] = $data;
+    }
+
+    public static function reset(): void
+    {
+        self::$fixtures = [];
+    }
+
+    public function getCustomer(): Customer
+    {
+        return $this->customer ?? new Customer();
+    }
+}


### PR DESCRIPTION
## Jira
https://packeta.atlassian.net/browse/PES-3252

## Názvosloví:
- UX/labely = „return/vratka" dle zadání, v kódu je použité claim kvůli konzistenci s ostatními moduly (WP, SH).

## PHPStan
- Součástí je oprava docblocku `DbTools::insert()` / `update()` — `@param false $nullValues` → `@param bool` (parametr reálně bere `bool`, ne jen literál `false`).
- Returns kód (`clearReturnPacket` zapisuje `NULL` → `$nullValues = true`) tak nepotřebuje novou baseline výjimku a navíc tím odpadlo 10 stávajících baseline výjimek (`CarrierRepository`, `OrderRepository`), které ten chybný typehint vynucoval.

## Validator
- 1 nový nález je false-positive, resp. nelze opravit kvůli PHP 7.1 floor. Baseline se nemění.     

## CSS-flex
- Toolbar s akcemi v gridu nově používá display:flex (CSS Flexbox), aby akce vratky zůstala v řádku s ostatními.
- Plně podporováno v Chrome 29+,Firefox 28+, Safari 9+, všech verzích Edge a v IE11 (se známými drobnými flexbox odchylkami).
- Oproti back office PrestaShopu 1.7+ nepřidává žádné nové omezení: to je postavené na Bootstrapu 4 (flex všude) a samo cílí jen poslední 2 verze major prohlížečů. 
