### PR TITLE
PES-3257: fix CZ/SK translations broken by wrong l() source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 /vendor/
 /packetery/views/js/write-test.js
 /packetery/packetery_error.log
+/packetery/config.xml
 /packetery/config_cs.xml
 /packetery/self_config.yml

--- a/packetery/CHANGE_LOG.txt
+++ b/packetery/CHANGE_LOG.txt
@@ -8,6 +8,7 @@
        - Updated: Multiple issues from PrestaShop validator resolved.
        - Updated: Added company to shipment submission via API.
        - Updated: Removed Czech language from Slovak translations.
+       - Fixed: Some Czech and Slovak texts were incorrectly displayed in English.
 3.3.1  - Fixed: Correct Ajax behavior in checkout if friendly URLs are not enabled.
 3.3.0  - Added: Support for PrestaShop 9.
        - Added: The option to enable API validation of the pickup location in the cart.

--- a/packetery/libs/Hooks/ActionValidateStepComplete.php
+++ b/packetery/libs/Hooks/ActionValidateStepComplete.php
@@ -59,7 +59,7 @@ class ActionValidateStepComplete
             \PrestaShopLogger::addLog('Cart is not present in hook parameters.', 3, null, null, null, true);
             $params['completed'] = false;
 
-            return $this->module->l('Order validation failed, shop owner can find more information in log.', 'ordervalidatestepcomplete');
+            return $this->module->l('Order validation failed, shop owner can find more information in log.', 'actionvalidatestepcomplete');
         }
 
         /** @var \CartCore $cart */
@@ -74,7 +74,7 @@ class ActionValidateStepComplete
         if ($isPickupPointCarrier === true && empty($orderData['id_branch'])) {
             $params['completed'] = false;
 
-            return $this->module->l('Please select pickup point.', 'ordervalidatestepcomplete');
+            return $this->module->l('Please select pickup point.', 'actionvalidatestepcomplete');
         }
 
         $isApiWidgetValidationModeEnabled = ConfigHelper::isApiWidgetValidationModeEnabled();
@@ -92,7 +92,7 @@ class ActionValidateStepComplete
             if ($pickupPointValidationResponse->isValid() === false) {
                 $params['completed'] = false;
 
-                return $this->module->l('The selected Packeta pickup point could not be validated. Please select another.', 'ordervalidatestepcomplete');
+                return $this->module->l('The selected Packeta pickup point could not be validated. Please select another.', 'actionvalidatestepcomplete');
             }
         }
 
@@ -105,7 +105,7 @@ class ActionValidateStepComplete
         if (!$orderData || !AddressTools::hasValidatedAddress($orderData)) {
             $params['completed'] = false;
 
-            return $this->module->l('Please use widget to validate address.', 'ordervalidatestepcomplete');
+            return $this->module->l('Please use widget to validate address.', 'actionvalidatestepcomplete');
         }
 
         $params['completed'] = true;

--- a/packetery/libs/PacketTracking/PacketTrackingCron.php
+++ b/packetery/libs/PacketTracking/PacketTrackingCron.php
@@ -72,7 +72,7 @@ class PacketTrackingCron
         $isPacketStatusTrackingEnabled = ConfigHelper::get('PACKETERY_PACKET_STATUS_TRACKING_ENABLED');
         if (!$isPacketStatusTrackingEnabled) {
             return [
-                'text' => $this->module->l('Packet status tracking is not active', 'packetrackingcron'),
+                'text' => $this->module->l('Packet status tracking is not active', 'packettrackingcron'),
                 'class' => 'danger',
             ];
         }
@@ -198,7 +198,7 @@ class PacketTrackingCron
         }
 
         return [
-            'text' => $this->module->l('Order statuses have been updated.', 'packetrackingcron'),
+            'text' => $this->module->l('Order statuses have been updated.', 'packettrackingcron'),
             'class' => 'success',
         ];
     }
@@ -235,7 +235,7 @@ class PacketTrackingCron
     public function getNoOrderStatusesMessage(): array
     {
         return [
-            'text' => $this->module->l('No order statuses configured for packet tracking', 'packetrackingcron'),
+            'text' => $this->module->l('No order statuses configured for packet tracking', 'packettrackingcron'),
             'class' => 'danger',
         ];
     }

--- a/packetery/libs/PickupPointValidate/PickupPointValidator.php
+++ b/packetery/libs/PickupPointValidate/PickupPointValidator.php
@@ -61,7 +61,7 @@ class PickupPointValidator
             $pickupPointValidate = PickupPointValidate::createWithValidApiKey($apiKey, $this->httpClient);
         } catch (InvalidApiKeyException $exception) {
             $record = [
-                'errorMessage' => $this->module->l('API credentials are not set corretly.', 'pickuptointvalidate'),
+                'errorMessage' => $this->module->l('API credentials are not set correctly.', 'pickuppointvalidator'),
             ];
 
             $this->logRepository->insertRow(LogRepository::ACTION_PICKUP_POINT_VALIDATE, $record, 'error');

--- a/packetery/translations/cs.php
+++ b/packetery/translations/cs.php
@@ -162,7 +162,7 @@ $_MODULE['<{packetery}prestashop>packetstatustrackingformservice_6b17a131b80b204
 $_MODULE['<{packetery}prestashop>packetstatustrackingformservice_b51795a24e5c65a16613d55607ec55ff'] = 'Maximální stáří objednávky ve dnech';
 $_MODULE['<{packetery}prestashop>packetstatustrackingformservice_33af8066d3c83110d4bd897f687cedd2'] = 'Stavy objednávek';
 $_MODULE['<{packetery}prestashop>packetstatustrackingformservice_d704d40d0a7f722008b45ccdc05f2b22'] = 'Stavy zásilek';
-$_MODULE['<{packetery}prestashop>pickuppointvalidator_32deda9da06d6c3ef4c538f206914203'] = 'Přístupové údaje k API nejsou správně nastaveny.';
+$_MODULE['<{packetery}prestashop>pickuppointvalidator_7dddc4f5f5fc20c0379b666e361358bb'] = 'Přístupové údaje k API nejsou správně nastaveny.';
 $_MODULE['<{packetery}prestashop>downloader_ae4593859212da2371dd8db75461239d'] = 'Stažení dopravců selhalo: %s Zkuste to prosím později.';
 $_MODULE['<{packetery}prestashop>downloader_962437147c581d5b304392ee8f920ce5'] = 'Nepodařilo se získat seznam.';
 $_MODULE['<{packetery}prestashop>downloader_a2b5e89ee86d19550fccf24d694324ee'] = 'Neplatná odpověď API.';

--- a/packetery/translations/sk.php
+++ b/packetery/translations/sk.php
@@ -162,7 +162,7 @@ $_MODULE['<{packetery}prestashop>packetstatustrackingformservice_6b17a131b80b204
 $_MODULE['<{packetery}prestashop>packetstatustrackingformservice_b51795a24e5c65a16613d55607ec55ff'] = 'Maximálny vek objednávky v dňoch';
 $_MODULE['<{packetery}prestashop>packetstatustrackingformservice_33af8066d3c83110d4bd897f687cedd2'] = 'Stavy objednávok';
 $_MODULE['<{packetery}prestashop>packetstatustrackingformservice_d704d40d0a7f722008b45ccdc05f2b22'] = 'Stavy zásielok';
-$_MODULE['<{packetery}prestashop>pickuppointvalidator_32deda9da06d6c3ef4c538f206914203'] = 'Prístupové údaje k API nie sú správne nastavené.';
+$_MODULE['<{packetery}prestashop>pickuppointvalidator_7dddc4f5f5fc20c0379b666e361358bb'] = 'Prístupové údaje k API nie sú správne nastavené.';
 $_MODULE['<{packetery}prestashop>downloader_ae4593859212da2371dd8db75461239d'] = 'Sťahovanie dopravcov zlyhalo: %s Skúste to prosím neskôr.';
 $_MODULE['<{packetery}prestashop>downloader_962437147c581d5b304392ee8f920ce5'] = 'Nepodarilo sa získať zoznam.';
 $_MODULE['<{packetery}prestashop>downloader_a2b5e89ee86d19550fccf24d694324ee'] = 'Neplatná odpoveď API.';


### PR DESCRIPTION
## Proč

Osm stringů se v CZ/SK e-shopech zobrazovalo anglicky, přestože správné překlady v `cs.php`/`sk.php` existují. Legacy `$_MODULE` lookup keyuje na `source` argument `l()`; nedávné commity ten source změnily/překlepnuly, takže se runtime klíč přestal trefovat a string spadl na anglický originál (ve všech verzích PS). Ověřeno, že rozbité source byly už ve vydané v3.3 → produkční CZ/SK uživatelé ty texty viděli anglicky.

## Co

Oprava `source` argumentu, aby seděl na existující překladové klíče:
- `ActionValidateStepComplete`: `ordervalidatestepcomplete` → `actionvalidatestepcomplete`
- `PacketTrackingCron`: `packetrackingcron` → `packettrackingcron`
- `PickupPointValidator`: `pickuptointvalidate` → `pickuppointvalidator`

Dále oprava anglického překlepu `corretly` → `correctly` v `PickupPointValidator` a přehashování jeho `cs.php`/`sk.php` záznamu na nový md5 (text překladu beze změny). Záznam v `CHANGE_LOG.txt`.

Samostatný commit: `.gitignore` pro auto-generovaný `packetery/config.xml` (forward-port pravidla z v3.5).

**Žádné nové překlady se nepřidávají.**

## Ověření

PS 1.7.8 / 8.2 / 9.1: `missing = 0`, `orphans = 0` (token-scan + živý test `l()`).

## Mimo scope

Nové stringy přidané ve v3.5, které nejsou přeložené, řeší samostatný ticket. Stejná oprava jde do v3.5 samostatným PR.
