### PR TITLE
PES-3257: fix CZ/SK translations broken by wrong l() source

### DIFF
--- a/packetery/libs/Hooks/ActionValidateStepComplete.php
+++ b/packetery/libs/Hooks/ActionValidateStepComplete.php
@@ -59,7 +59,7 @@ class ActionValidateStepComplete
             \PrestaShopLogger::addLog('Cart is not present in hook parameters.', 3, null, null, null, true);
             $params['completed'] = false;
 
-            return $this->module->l('Order validation failed, shop owner can find more information in log.', 'ordervalidatestepcomplete');
+            return $this->module->l('Order validation failed, shop owner can find more information in log.', 'actionvalidatestepcomplete');
         }
 
         /** @var \CartCore $cart */
@@ -74,7 +74,7 @@ class ActionValidateStepComplete
         if ($isPickupPointCarrier === true && empty($orderData['id_branch'])) {
             $params['completed'] = false;
 
-            return $this->module->l('Please select pickup point.', 'ordervalidatestepcomplete');
+            return $this->module->l('Please select pickup point.', 'actionvalidatestepcomplete');
         }
 
         $isApiWidgetValidationModeEnabled = ConfigHelper::isApiWidgetValidationModeEnabled();
@@ -92,7 +92,7 @@ class ActionValidateStepComplete
             if ($pickupPointValidationResponse->isValid() === false) {
                 $params['completed'] = false;
 
-                return $this->module->l('The selected Packeta pickup point could not be validated. Please select another.', 'ordervalidatestepcomplete');
+                return $this->module->l('The selected Packeta pickup point could not be validated. Please select another.', 'actionvalidatestepcomplete');
             }
         }
 
@@ -105,7 +105,7 @@ class ActionValidateStepComplete
         if (!$orderData || !AddressTools::hasValidatedAddress($orderData)) {
             $params['completed'] = false;
 
-            return $this->module->l('Please use widget to validate address.', 'ordervalidatestepcomplete');
+            return $this->module->l('Please use widget to validate address.', 'actionvalidatestepcomplete');
         }
 
         $params['completed'] = true;

--- a/packetery/libs/PacketTracking/PacketTrackingCron.php
+++ b/packetery/libs/PacketTracking/PacketTrackingCron.php
@@ -72,7 +72,7 @@ class PacketTrackingCron
         $isPacketStatusTrackingEnabled = ConfigHelper::get('PACKETERY_PACKET_STATUS_TRACKING_ENABLED');
         if (!$isPacketStatusTrackingEnabled) {
             return [
-                'text' => $this->module->l('Packet status tracking is not active', 'packetrackingcron'),
+                'text' => $this->module->l('Packet status tracking is not active', 'packettrackingcron'),
                 'class' => 'danger',
             ];
         }
@@ -198,7 +198,7 @@ class PacketTrackingCron
         }
 
         return [
-            'text' => $this->module->l('Order statuses have been updated.', 'packetrackingcron'),
+            'text' => $this->module->l('Order statuses have been updated.', 'packettrackingcron'),
             'class' => 'success',
         ];
     }
@@ -235,7 +235,7 @@ class PacketTrackingCron
     public function getNoOrderStatusesMessage(): array
     {
         return [
-            'text' => $this->module->l('No order statuses configured for packet tracking', 'packetrackingcron'),
+            'text' => $this->module->l('No order statuses configured for packet tracking', 'packettrackingcron'),
             'class' => 'danger',
         ];
     }

--- a/packetery/libs/PickupPointValidate/PickupPointValidator.php
+++ b/packetery/libs/PickupPointValidate/PickupPointValidator.php
@@ -61,7 +61,7 @@ class PickupPointValidator
             $pickupPointValidate = PickupPointValidate::createWithValidApiKey($apiKey, $this->httpClient);
         } catch (InvalidApiKeyException $exception) {
             $record = [
-                'errorMessage' => $this->module->l('API credentials are not set corretly.', 'pickuptointvalidate'),
+                'errorMessage' => $this->module->l('API credentials are not set correctly.', 'pickuppointvalidator'),
             ];
 
             $this->logRepository->insertRow(LogRepository::ACTION_PICKUP_POINT_VALIDATE, $record, 'error');

--- a/packetery/translations/cs.php
+++ b/packetery/translations/cs.php
@@ -162,7 +162,7 @@ $_MODULE['<{packetery}prestashop>packetstatustrackingformservice_6b17a131b80b204
 $_MODULE['<{packetery}prestashop>packetstatustrackingformservice_b51795a24e5c65a16613d55607ec55ff'] = 'Maximální stáří objednávky ve dnech';
 $_MODULE['<{packetery}prestashop>packetstatustrackingformservice_33af8066d3c83110d4bd897f687cedd2'] = 'Stavy objednávek';
 $_MODULE['<{packetery}prestashop>packetstatustrackingformservice_d704d40d0a7f722008b45ccdc05f2b22'] = 'Stavy zásilek';
-$_MODULE['<{packetery}prestashop>pickuppointvalidator_32deda9da06d6c3ef4c538f206914203'] = 'Přístupové údaje k API nejsou správně nastaveny.';
+$_MODULE['<{packetery}prestashop>pickuppointvalidator_7dddc4f5f5fc20c0379b666e361358bb'] = 'Přístupové údaje k API nejsou správně nastaveny.';
 $_MODULE['<{packetery}prestashop>downloader_ae4593859212da2371dd8db75461239d'] = 'Stažení dopravců selhalo: %s Zkuste to prosím později.';
 $_MODULE['<{packetery}prestashop>downloader_962437147c581d5b304392ee8f920ce5'] = 'Nepodařilo se získat seznam.';
 $_MODULE['<{packetery}prestashop>downloader_a2b5e89ee86d19550fccf24d694324ee'] = 'Neplatná odpověď API.';

--- a/packetery/translations/sk.php
+++ b/packetery/translations/sk.php
@@ -162,7 +162,7 @@ $_MODULE['<{packetery}prestashop>packetstatustrackingformservice_6b17a131b80b204
 $_MODULE['<{packetery}prestashop>packetstatustrackingformservice_b51795a24e5c65a16613d55607ec55ff'] = 'Maximálny vek objednávky v dňoch';
 $_MODULE['<{packetery}prestashop>packetstatustrackingformservice_33af8066d3c83110d4bd897f687cedd2'] = 'Stavy objednávok';
 $_MODULE['<{packetery}prestashop>packetstatustrackingformservice_d704d40d0a7f722008b45ccdc05f2b22'] = 'Stavy zásielok';
-$_MODULE['<{packetery}prestashop>pickuppointvalidator_32deda9da06d6c3ef4c538f206914203'] = 'Prístupové údaje k API nie sú správne nastavené.';
+$_MODULE['<{packetery}prestashop>pickuppointvalidator_7dddc4f5f5fc20c0379b666e361358bb'] = 'Prístupové údaje k API nie sú správne nastavené.';
 $_MODULE['<{packetery}prestashop>downloader_ae4593859212da2371dd8db75461239d'] = 'Sťahovanie dopravcov zlyhalo: %s Skúste to prosím neskôr.';
 $_MODULE['<{packetery}prestashop>downloader_962437147c581d5b304392ee8f920ce5'] = 'Nepodarilo sa získať zoznam.';
 $_MODULE['<{packetery}prestashop>downloader_a2b5e89ee86d19550fccf24d694324ee'] = 'Neplatná odpoveď API.';


### PR DESCRIPTION
## Proč

Stejná oprava jako v #460 (v3.4): osm stringů se v CZ/SK e-shopech zobrazovalo anglicky, protože legacy `$_MODULE` lookup keyuje na `source` argument `l()` a ten byl změněný/překlepnutý → klíč se netrefil a string spadl na anglický originál.

## Co

Oprava `source` argumentu na existující překladové klíče:
- `ActionValidateStepComplete`: `ordervalidatestepcomplete` → `actionvalidatestepcomplete`
- `PacketTrackingCron`: `packetrackingcron` → `packettrackingcron`
- `PickupPointValidator`: `pickuptointvalidate` → `pickuppointvalidator`

Plus anglický překlep `corretly` → `correctly` v `PickupPointValidator` + přehash jeho `cs.php`/`sk.php` záznamu (text překladu beze změny). Žádné nové překlady.

CHANGE_LOG záznam tu není záměrně — fix dokumentuje 3.4.0 (vydáno dřív).

## Ověření

Ověřeno, že naše 3 cílové source jsou po fixu čisté (nejsou v missing ani orphans).

## Mimo scope

v3.5 má i další nepřeložené stringy z nových fičur (44 missing / 9 orphans, pre-existing) — řeší samostatný ticket, tento PR se jich nedotýká.
