### PR TITLE
PES-3255: extract carrier vendor logic into CarrierFieldsResolver

### DIFF
--- a/packetery/libs/Carrier/CarrierAdminForm.php
+++ b/packetery/libs/Carrier/CarrierAdminForm.php
@@ -28,11 +28,6 @@ class CarrierAdminForm
     private const ADDRESS_VALIDATION_OPTIONAL = 'optional';
 
     /**
-     * @var CarrierVendors
-     */
-    private $vendors;
-
-    /**
      * @var CarrierRepository
      */
     private $repository;
@@ -67,7 +62,6 @@ class CarrierAdminForm
     {
         $this->carrierId = $carrierId;
         $this->module = $module;
-        $this->vendors = $this->module->diContainer->get(CarrierVendors::class);
         $this->repository = $this->module->diContainer->get(CarrierRepository::class);
         $this->apiRepository = $this->module->diContainer->get(ApiCarrierRepository::class);
         $this->tools = $this->module->diContainer->get(CarrierTools::class);
@@ -239,7 +233,7 @@ class CarrierAdminForm
             $this->saveCarrierOptions($carrierData, $apiCarrier);
         }
 
-        $possibleVendors = $this->getPossibleVendors($carrierData);
+        $possibleVendors = $this->carrierFieldsResolver->getPossibleVendors($carrierData, $this->carrierId, $apiCarrier);
         $formInputs = [];
         if ((bool) $apiCarrier['is_pickup_points'] === false) {
             if ($this->carrierFieldsResolver->supportsAddressValidation($apiCarrier['country'])) {
@@ -559,7 +553,7 @@ class CarrierAdminForm
      */
     private function getAllowedVendorsFromForm(array $formData, $carrierData)
     {
-        $possibleVendors = $this->getPossibleVendors($carrierData);
+        $possibleVendors = $this->carrierFieldsResolver->getPossibleVendors($carrierData, $this->carrierId);
 
         if ($possibleVendors === [] || !isset($formData['allowed_vendors'])) {
             return ['error' => $this->module->l('You must select at least one vendor for each country.', 'carrieradminform')];
@@ -588,32 +582,6 @@ class CarrierAdminForm
     }
 
     /**
-     * @param array $carrierData
-     * @param array|bool|object|null $apiCarrier
-     *
-     * @return array
-     *
-     * @throws DatabaseException
-     */
-    private function getPossibleVendors(array $carrierData, $apiCarrier = null)
-    {
-        if (!isset($carrierData['id_branch'])) {
-            return [];
-        }
-        if ($apiCarrier === null) {
-            $apiCarrier = $this->apiRepository->getById($carrierData['id_branch']);
-        }
-
-        if ($apiCarrier['id'] === \Packetery::PP_ALL || $apiCarrier['id'] === \Packetery::ZPOINT) {
-            $countries = $this->tools->getCountries($this->carrierId, 'iso_code');
-        } else {
-            $countries = [$apiCarrier['country']];
-        }
-
-        return $this->vendors->getVendorsByCountries($countries);
-    }
-
-    /**
      * @return array
      */
     private function getBackButton()
@@ -627,23 +595,12 @@ class CarrierAdminForm
 
     /**
      * @param array $carrierData
-     * @param array|null $apiCarrier
+     * @param array $apiCarrier
      *
      * @throws DatabaseException
      */
     public function getDefaultAllowedVendors(array $carrierData, $apiCarrier): ?string
     {
-        $allowedVendorsJson = null;
-        if ($carrierData['id_branch'] === \Packetery::ZPOINT || $carrierData['id_branch'] === \Packetery::PP_ALL) {
-            $possibleVendors = $this->getPossibleVendors($carrierData, $apiCarrier);
-            $allowedVendorsArray = [];
-            // Allow all by default.
-            foreach ($possibleVendors as $country => $vendors) {
-                $allowedVendorsArray[$country] = array_column($vendors, 'group');
-            }
-            $allowedVendorsJson = json_encode($allowedVendorsArray);
-        }
-
-        return $allowedVendorsJson;
+        return $this->carrierFieldsResolver->getDefaultAllowedVendors($carrierData, $this->carrierId, $apiCarrier);
     }
 }

--- a/packetery/libs/Carrier/CarrierFieldsResolver.php
+++ b/packetery/libs/Carrier/CarrierFieldsResolver.php
@@ -12,10 +12,31 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 
+use Packetery\ApiCarrier\ApiCarrierRepository;
+
 class CarrierFieldsResolver
 {
     private const PICKUP_POINT_TYPE_INTERNAL = 'internal';
     private const PICKUP_POINT_TYPE_EXTERNAL = 'external';
+
+    /** @var ApiCarrierRepository */
+    private $apiCarrierRepository;
+
+    /** @var CarrierTools */
+    private $carrierTools;
+
+    /** @var CarrierVendors */
+    private $carrierVendors;
+
+    public function __construct(
+        ApiCarrierRepository $apiCarrierRepository,
+        CarrierTools $carrierTools,
+        CarrierVendors $carrierVendors
+    ) {
+        $this->apiCarrierRepository = $apiCarrierRepository;
+        $this->carrierTools = $carrierTools;
+        $this->carrierVendors = $carrierVendors;
+    }
 
     /**
      * @param array{is_pickup_points: mixed} $apiCarrier
@@ -54,5 +75,57 @@ class CarrierFieldsResolver
     public function supportsAddressValidation(string $country): bool
     {
         return in_array(strtoupper($country), CarrierRepository::ADDRESS_VALIDATION_COUNTRIES, true);
+    }
+
+    /**
+     * @param array|false|null $apiCarrier
+     *
+     * @throws \Packetery\Exceptions\DatabaseException
+     */
+    public function getPossibleVendors(array $carrierData, int $carrierId, $apiCarrier = null): array
+    {
+        if (!isset($carrierData['id_branch'])) {
+            return [];
+        }
+        if ($apiCarrier === null) {
+            $apiCarrier = $this->apiCarrierRepository->getById($carrierData['id_branch']);
+        }
+        if (!is_array($apiCarrier)) {
+            return [];
+        }
+
+        if ($apiCarrier['id'] === \Packetery::PP_ALL || $apiCarrier['id'] === \Packetery::ZPOINT) {
+            $countries = $this->carrierTools->getCountries($carrierId, 'iso_code');
+        } else {
+            $countries = [$apiCarrier['country']];
+        }
+
+        return $this->carrierVendors->getVendorsByCountries($countries);
+    }
+
+    /**
+     * @param array|false $apiCarrier
+     *
+     * @throws \Packetery\Exceptions\DatabaseException
+     */
+    public function getDefaultAllowedVendors(array $carrierData, int $carrierId, $apiCarrier): ?string
+    {
+        if (!isset($carrierData['id_branch'])) {
+            return null;
+        }
+
+        $allowedVendorsJson = null;
+        if ($carrierData['id_branch'] === \Packetery::ZPOINT || $carrierData['id_branch'] === \Packetery::PP_ALL) {
+            $possibleVendors = $this->getPossibleVendors($carrierData, $carrierId, $apiCarrier);
+            $allowedVendorsArray = [];
+
+            // Allow all by default
+            foreach ($possibleVendors as $country => $vendors) {
+                $allowedVendorsArray[$country] = array_column($vendors, 'group');
+            }
+            $allowedVendorsJson = (string) json_encode($allowedVendorsArray);
+        }
+
+        return $allowedVendorsJson;
     }
 }

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * @author    Packeta s.r.o. <e-commerce.support@packeta.com>
+ * @copyright 2015-2026 Packeta s.r.o.
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Packetery\Tests;
+
+use Packetery\ApiCarrier\ApiCarrierRepository;
+use Packetery\Carrier\CarrierTools;
+use Packetery\Carrier\CarrierVendors;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+
+abstract class BaseTest extends TestCase
+{
+    protected const CARRIER_ID = 5;
+
+    protected const COUNTRY_CZ = 'cz';
+    protected const COUNTRY_SK = 'sk';
+    protected const COUNTRY_DE = 'de';
+
+    protected const VENDORS_CZ = [
+        self::COUNTRY_CZ => [
+            [
+                'group' => CarrierVendors::VENDOR_GROUP_ZPOINT,
+                'country' => self::COUNTRY_CZ,
+                'name' => 'Packeta Pick-up Points',
+            ],
+            [
+                'group' => 'zbox',
+                'country' => self::COUNTRY_CZ,
+                'name' => 'Packeta Z-BOX',
+            ],
+        ],
+    ];
+
+    // CZ + SK both run Packeta zpoint + Z-BOX
+    protected const VENDORS_CZ_SK = [
+        self::COUNTRY_CZ => [
+            [
+                'group' => CarrierVendors::VENDOR_GROUP_ZPOINT,
+                'country' => self::COUNTRY_CZ,
+                'name' => 'Packeta Pick-up Points',
+            ],
+            [
+                'group' => 'zbox',
+                'country' => self::COUNTRY_CZ,
+                'name' => 'Packeta Z-BOX',
+            ],
+        ],
+        self::COUNTRY_SK => [
+            [
+                'group' => CarrierVendors::VENDOR_GROUP_ZPOINT,
+                'country' => self::COUNTRY_SK,
+                'name' => 'Packeta Pick-up Points',
+            ],
+            [
+                'group' => 'zbox',
+                'country' => self::COUNTRY_SK,
+                'name' => 'Packeta Z-BOX',
+            ],
+        ],
+    ];
+
+    /**
+     * \Packetery stub whose l() returns the marker unchanged.
+     *
+     * @return Stub&\Packetery
+     */
+    protected function createPacketeryStub(): \Packetery
+    {
+        $module = $this->createStub(\Packetery::class);
+        $module
+            ->method('l')
+            ->willReturnArgument(0);
+
+        return $module;
+    }
+
+    /**
+     * @return Stub&ApiCarrierRepository
+     */
+    protected function createApiCarrierRepositoryStub(): ApiCarrierRepository
+    {
+        return $this->createStub(ApiCarrierRepository::class);
+    }
+
+    /**
+     * @return Stub&CarrierTools
+     */
+    protected function createCarrierToolsStub(): CarrierTools
+    {
+        return $this->createStub(CarrierTools::class);
+    }
+
+    /**
+     * Invoke a private or protected method via reflection
+     *
+     * @param array<int, mixed> $args
+     * @throws \ReflectionException
+     */
+    protected function invokeMethod(object $object, string $method, array $args = []): mixed
+    {
+        return (new \ReflectionClass($object))
+            ->getMethod($method)
+            ->invokeArgs($object, $args);
+    }
+
+    /**
+     * Set a private or protected property via reflection
+     *
+     * @param mixed $value
+     * @throws \ReflectionException
+     */
+    protected function mockPrivateProperty(
+        object $target,
+        string $property,
+        $value
+    ): void {
+        (new \ReflectionClass($target))
+            ->getProperty($property)
+            ->setValue($target, $value);
+    }
+}

--- a/tests/Unit/Carrier/CarrierAdminFormAllowedVendorsTest.php
+++ b/tests/Unit/Carrier/CarrierAdminFormAllowedVendorsTest.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * @author    Packeta s.r.o. <e-commerce.support@packeta.com>
+ * @copyright 2015-2026 Packeta s.r.o.
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Packetery\Tests\Unit\Carrier;
+
+use Packetery\Carrier\CarrierAdminForm;
+use Packetery\Carrier\CarrierFieldsResolver;
+use Packetery\Carrier\CarrierVendors;
+use Packetery\Tests\BaseTest;
+use PHPUnit\Framework\Attributes\DataProvider;
+use ReflectionClass;
+
+/**
+ * Reflection test for the private CarrierAdminForm::getAllowedVendorsFromForm() validation branches,
+ * including "selected vendor not available", which the admin UI cannot reach.
+ */
+class CarrierAdminFormAllowedVendorsTest extends BaseTest
+{
+    private const ERROR_KEY = 'error';
+
+    /**
+     * @param array<string, mixed> $possibleVendors
+     * @param array<string, mixed> $formData
+     */
+    #[DataProvider('invalidSelectionProvider')]
+    public function testReturnsErrorForInvalidSelection(array $possibleVendors, array $formData): void
+    {
+        $result = $this->invokeWithPossibleVendors($possibleVendors, $formData);
+
+        $this->assertArrayHasKey(self::ERROR_KEY, $result);
+    }
+
+    /**
+     * @return array<string, array{array<string, mixed>, array<string, mixed>}>
+     */
+    public static function invalidSelectionProvider(): array
+    {
+        return [
+            'no vendor selected' => [
+                self::VENDORS_CZ,
+                [],
+            ],
+            'country missing in form' => [
+                self::VENDORS_CZ,
+                [
+                    'allowed_vendors' => [
+                        self::COUNTRY_SK => [
+                            CarrierVendors::VENDOR_GROUP_ZPOINT => 'on',
+                        ],
+                    ],
+                ],
+            ],
+            'vendor not available' => [
+                self::VENDORS_CZ,
+                [
+                    'allowed_vendors' => [
+                        self::COUNTRY_CZ => [
+                            'nonexistent' => 'on',
+                        ],
+                    ],
+                ],
+            ],
+            'no possible vendors' => [
+                [],
+                [
+                    'allowed_vendors' => [
+                        self::COUNTRY_CZ => [
+                            CarrierVendors::VENDOR_GROUP_ZPOINT => 'on',
+                        ],
+                    ],
+                ],
+            ],
+            'multi-country partial selection' => [
+                self::VENDORS_CZ_SK,
+                [
+                    'allowed_vendors' => [
+                        self::COUNTRY_CZ => [
+                            CarrierVendors::VENDOR_GROUP_ZPOINT => 'on',
+                            'zbox' => 'on',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $possibleVendors
+     * @param array<string, mixed> $formData
+     * @param array<string, list<string>> $expected
+     */
+    #[DataProvider('validSelectionProvider')]
+    public function testReturnsAllowedVendorsForValidSelection(
+        array $possibleVendors,
+        array $formData,
+        array $expected
+    ): void {
+        $result = $this->invokeWithPossibleVendors($possibleVendors, $formData);
+
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * @return array<string, array{array<string, mixed>, array<string, mixed>, array<string, list<string>>}>
+     */
+    public static function validSelectionProvider(): array
+    {
+        return [
+            'single country' => [
+                self::VENDORS_CZ,
+                [
+                    'allowed_vendors' => [
+                        self::COUNTRY_CZ => [
+                            CarrierVendors::VENDOR_GROUP_ZPOINT => 'on',
+                            'zbox' => 'on',
+                        ],
+                    ],
+                ],
+                [
+                    self::COUNTRY_CZ => [
+                        CarrierVendors::VENDOR_GROUP_ZPOINT,
+                        'zbox',
+                    ],
+                ],
+            ],
+            'multi-country cz+sk' => [
+                self::VENDORS_CZ_SK,
+                [
+                    'allowed_vendors' => [
+                        self::COUNTRY_CZ => [
+                            CarrierVendors::VENDOR_GROUP_ZPOINT => 'on',
+                            'zbox' => 'on',
+                        ],
+                        self::COUNTRY_SK => [
+                            CarrierVendors::VENDOR_GROUP_ZPOINT => 'on',
+                            'zbox' => 'on',
+                        ],
+                    ],
+                ],
+                [
+                    self::COUNTRY_CZ => [
+                        CarrierVendors::VENDOR_GROUP_ZPOINT,
+                        'zbox',
+                    ],
+                    self::COUNTRY_SK => [
+                        CarrierVendors::VENDOR_GROUP_ZPOINT,
+                        'zbox',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $possibleVendors
+     * @param array<string, mixed> $formData
+     *
+     * @return array<string, mixed>
+     *
+     * @throws \ReflectionException
+     */
+    private function invokeWithPossibleVendors(array $possibleVendors, array $formData): array
+    {
+        $carrierFieldsResolver = $this->createStub(CarrierFieldsResolver::class);
+        $carrierFieldsResolver
+            ->method('getPossibleVendors')
+            ->willReturn($possibleVendors);
+
+        $form = (new ReflectionClass(CarrierAdminForm::class))->newInstanceWithoutConstructor();
+        $this->mockPrivateProperty($form, 'carrierFieldsResolver', $carrierFieldsResolver);
+        $this->mockPrivateProperty($form, 'carrierId', self::CARRIER_ID);
+        $this->mockPrivateProperty($form, 'module', $this->createPacketeryStub());
+
+        return $this->invokeMethod($form, 'getAllowedVendorsFromForm', [$formData, []]);
+    }
+}

--- a/tests/Unit/Carrier/CarrierFieldsResolverTest.php
+++ b/tests/Unit/Carrier/CarrierFieldsResolverTest.php
@@ -1,0 +1,276 @@
+<?php
+/**
+ * @author    Packeta s.r.o. <e-commerce.support@packeta.com>
+ * @copyright 2015-2026 Packeta s.r.o.
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Packetery\Tests\Unit\Carrier;
+
+use Packetery\ApiCarrier\ApiCarrierRepository;
+use Packetery\Carrier\CarrierFieldsResolver;
+use Packetery\Carrier\CarrierTools;
+use Packetery\Carrier\CarrierVendors;
+use Packetery\Tests\BaseTest;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class CarrierFieldsResolverTest extends BaseTest
+{
+    private const string EXTERNAL_BRANCH_ID = '13';
+
+    public function testGetPossibleVendorsEmptyWhenBranchMissing(): void
+    {
+        $apiCarrierRepository = $this->createMock(ApiCarrierRepository::class);
+        $carrierVendors = $this->createMock(CarrierVendors::class);
+
+        $apiCarrierRepository
+            ->expects($this->never())
+            ->method('getById');
+        $carrierVendors
+            ->expects($this->never())
+            ->method('getVendorsByCountries');
+
+        $resolver = new CarrierFieldsResolver(
+            $apiCarrierRepository,
+            $this->createCarrierToolsStub(),
+            $carrierVendors
+        );
+
+        $this->assertSame([], $resolver->getPossibleVendors([], self::CARRIER_ID));
+    }
+
+    #[DataProvider('internalBranchProvider')]
+    public function testGetPossibleVendorsForInternalCarrier(string $idBranch): void
+    {
+        $carrierTools = $this->createMock(CarrierTools::class);
+        $carrierVendors = $this->createMock(CarrierVendors::class);
+
+        $carrierTools
+            ->expects($this->once())
+            ->method('getCountries')
+            ->with(self::CARRIER_ID, 'iso_code')
+            ->willReturn([self::COUNTRY_CZ]);
+        $carrierVendors
+            ->expects($this->once())
+            ->method('getVendorsByCountries')
+            ->with([self::COUNTRY_CZ])
+            ->willReturn(self::VENDORS_CZ);
+
+        $resolver = new CarrierFieldsResolver(
+            $this->createApiCarrierRepositoryStub(),
+            $carrierTools,
+            $carrierVendors
+        );
+
+        $result = $resolver->getPossibleVendors(
+            ['id_branch' => $idBranch],
+            self::CARRIER_ID,
+            ['id' => $idBranch]
+        );
+
+        $this->assertSame(self::VENDORS_CZ, $result);
+    }
+
+    public function testGetPossibleVendorsForExternalCarrier(): void
+    {
+        $carrierTools = $this->createMock(CarrierTools::class);
+        $carrierVendors = $this->createMock(CarrierVendors::class);
+
+        $carrierTools
+            ->expects($this->never())
+            ->method('getCountries');
+        $carrierVendors
+            ->expects($this->once())
+            ->method('getVendorsByCountries')
+            ->with([self::COUNTRY_DE])
+            ->willReturn([]);
+
+        $resolver = new CarrierFieldsResolver(
+            $this->createApiCarrierRepositoryStub(),
+            $carrierTools,
+            $carrierVendors
+        );
+
+        $result = $resolver->getPossibleVendors(
+            ['id_branch' => self::EXTERNAL_BRANCH_ID],
+            self::CARRIER_ID,
+            [
+                'id' => self::EXTERNAL_BRANCH_ID,
+                'country' => self::COUNTRY_DE,
+            ]
+        );
+
+        $this->assertSame([], $result);
+    }
+
+    public function testGetPossibleVendorsFetchesApiCarrierWhenNotProvided(): void
+    {
+        $apiCarrierRepository = $this->createMock(ApiCarrierRepository::class);
+        $carrierTools = $this->createCarrierToolsStub();
+        $carrierVendors = $this->createStub(CarrierVendors::class);
+
+        $apiCarrierRepository
+            ->expects($this->once())
+            ->method('getById')
+            ->with(\Packetery::ZPOINT)
+            ->willReturn(['id' => \Packetery::ZPOINT, 'country' => self::COUNTRY_CZ]);
+        $carrierTools
+            ->method('getCountries')
+            ->willReturn([self::COUNTRY_CZ]);
+        $carrierVendors
+            ->method('getVendorsByCountries')
+            ->willReturn(self::VENDORS_CZ);
+
+        $resolver = new CarrierFieldsResolver(
+            $apiCarrierRepository,
+            $carrierTools,
+            $carrierVendors
+        );
+
+        $this->assertSame(
+            self::VENDORS_CZ,
+            $resolver->getPossibleVendors(
+                ['id_branch' => \Packetery::ZPOINT],
+                self::CARRIER_ID
+            )
+        );
+    }
+
+    #[DataProvider('apiCarrierNotFoundProvider')]
+    public function testGetPossibleVendorsEmptyWhenApiCarrierNotFound($getByIdResult): void
+    {
+        $apiCarrierRepository = $this->createMock(ApiCarrierRepository::class);
+        $carrierVendors = $this->createMock(CarrierVendors::class);
+
+        $apiCarrierRepository
+            ->expects($this->once())
+            ->method('getById')
+            ->with(\Packetery::ZPOINT)
+            ->willReturn($getByIdResult);
+        $carrierVendors
+            ->expects($this->never())
+            ->method('getVendorsByCountries');
+
+        $resolver = new CarrierFieldsResolver(
+            $apiCarrierRepository,
+            $this->createCarrierToolsStub(),
+            $carrierVendors
+        );
+
+        $this->assertSame(
+            [],
+            $resolver->getPossibleVendors(
+                ['id_branch' => \Packetery::ZPOINT],
+                self::CARRIER_ID
+            )
+        );
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function apiCarrierNotFoundProvider(): array
+    {
+        return [
+            'getById false' => [false],
+            'getById null' => [null],
+        ];
+    }
+
+    #[DataProvider('defaultAllowedVendorsProvider')]
+    public function testGetDefaultAllowedVendorsBuildsJsonForInternalCarrier(
+        string $idBranch,
+        array $countries,
+        array $vendors,
+        string $expectedJson
+    ): void {
+        $carrierTools = $this->createCarrierToolsStub();
+        $carrierVendors = $this->createStub(CarrierVendors::class);
+
+        $carrierTools
+            ->method('getCountries')
+            ->willReturn($countries);
+        $carrierVendors
+            ->method('getVendorsByCountries')
+            ->willReturn($vendors);
+
+        $resolver = new CarrierFieldsResolver(
+            $this->createApiCarrierRepositoryStub(),
+            $carrierTools,
+            $carrierVendors
+        );
+
+        $result = $resolver->getDefaultAllowedVendors(
+            ['id_branch' => $idBranch],
+            self::CARRIER_ID,
+            ['id' => $idBranch]
+        );
+
+        $this->assertSame($expectedJson, $result);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function internalBranchProvider(): array
+    {
+        return [
+            'zpoint branch' => [\Packetery::ZPOINT],
+            'pp_all branch' => [\Packetery::PP_ALL],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string, list<string>, array<string, mixed>, string}>
+     */
+    public static function defaultAllowedVendorsProvider(): array
+    {
+        return [
+            'zpoint single country' => [
+                \Packetery::ZPOINT,
+                [self::COUNTRY_CZ],
+                self::VENDORS_CZ,
+                '{"cz":["zpoint","zbox"]}',
+            ],
+            'pp_all single country' => [
+                \Packetery::PP_ALL,
+                [self::COUNTRY_CZ],
+                self::VENDORS_CZ,
+                '{"cz":["zpoint","zbox"]}',
+            ],
+            'zpoint multiple countries' => [
+                \Packetery::ZPOINT,
+                [self::COUNTRY_CZ, self::COUNTRY_SK],
+                self::VENDORS_CZ_SK,
+                '{"cz":["zpoint","zbox"],"sk":["zpoint","zbox"]}',
+            ],
+        ];
+    }
+
+    public function testGetDefaultAllowedVendorsReturnsNullForExternalCarrier(): void
+    {
+        $carrierVendors = $this->createMock(CarrierVendors::class);
+
+        $carrierVendors
+            ->expects($this->never())
+            ->method('getVendorsByCountries');
+
+        $resolver = new CarrierFieldsResolver(
+            $this->createApiCarrierRepositoryStub(),
+            $this->createCarrierToolsStub(),
+            $carrierVendors
+        );
+
+        $this->assertNull(
+            $resolver->getDefaultAllowedVendors(
+                ['id_branch' => self::EXTERNAL_BRANCH_ID],
+                self::CARRIER_ID,
+                [
+                    'id' => self::EXTERNAL_BRANCH_ID,
+                    'country' => self::COUNTRY_DE,
+                ]
+            )
+        );
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -15,3 +15,4 @@ if (!defined('_PS_VERSION_')) {
 require __DIR__ . '/../vendor/autoload.php';
 require __DIR__ . '/../packetery/autoload.php';
 require __DIR__ . '/stubs/Configuration.php';
+require __DIR__ . '/stubs/Packetery.php';

--- a/tests/stubs/Packetery.php
+++ b/tests/stubs/Packetery.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @author    Packeta s.r.o. <e-commerce.support@packeta.com>
+ * @copyright 2015-2026 Packeta s.r.o.
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+declare(strict_types=1);
+
+class Packetery
+{
+    public const ZPOINT = 'zpoint';
+    public const PP_ALL = 'pp_all';
+
+    public function l(string $string, ...$arguments): string
+    {
+        return $string;
+    }
+}


### PR DESCRIPTION

[PES-3255](https://packeta.atlassian.net/browse/PES-3255)


### Info k testům
- BaseTest: nová sdílená bázová třída pro testy (inspirace v MG)
- CarrierAdminFormAllowedVendorsTest: trochu nad rámec čisté extrakce: přes reflexi pokrývá validační větve getAllowedVendorsFromForm. Do budoucna by metoda potřebovala další refactor, ideálně extrakci do vlastní service.

[PES-3255]: https://packeta.atlassian.net/browse/PES-3255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ