### PR TITLE
Trim PHPStan baseline by fixing resolvable errors

### DIFF
--- a/packetery/controllers/admin/PacketeryCarrierGridController.php
+++ b/packetery/controllers/admin/PacketeryCarrierGridController.php
@@ -64,9 +64,9 @@ class PacketeryCarrierGridController extends ModuleAdminController
         $packeteryCarriers = $carrierRepository->getPacketeryCarriersList();
         $this->availableCarriers = array_combine(array_column($packeteryCarriers, 'id_branch'), array_column($packeteryCarriers, 'name_branch'));
         foreach ($this->availableCarriers as $carrierId => $carrierName) {
-            if ($carrierId === Packetery::ZPOINT && empty($carrierName)) {
+            if ($carrierId === Packetery::ZPOINT && ($carrierName === null || $carrierName === '')) {
                 $this->availableCarriers[Packetery::ZPOINT] = $this->module->l('Packeta pickup points', 'packeterycarriergridcontroller');
-            } elseif ($carrierId === Packetery::PP_ALL && empty($carrierName)) {
+            } elseif ($carrierId === Packetery::PP_ALL && ($carrierName === null || $carrierName === '')) {
                 $this->availableCarriers[Packetery::PP_ALL] = $this->module->l('Packeta pickup points (Packeta + carriers)', 'packeterycarriergridcontroller');
             }
         }

--- a/packetery/controllers/admin/PacketeryOrderGridController.php
+++ b/packetery/controllers/admin/PacketeryOrderGridController.php
@@ -644,7 +644,7 @@ class PacketeryOrderGridController extends ModuleAdminController
      */
     public function getTrackingLink($trackingNumber)
     {
-        if (empty($trackingNumber)) {
+        if ($trackingNumber === null || $trackingNumber === '') {
             return '';
         }
         $smarty = $this->getModule()->getContext()->smarty;
@@ -665,7 +665,7 @@ class PacketeryOrderGridController extends ModuleAdminController
      */
     public function getReferenceColumnValue($columnValue, array $row)
     {
-        if (empty($row['id_order'])) {
+        if ((int) ($row['id_order'] ?? 0) === 0) {
             return $columnValue;
         }
         $orderLink = $this->getModule()->getAdminLink('AdminOrders', ['id_order' => $row['id_order'], 'vieworder' => true], '#packetaPickupPointChange');
@@ -684,7 +684,7 @@ class PacketeryOrderGridController extends ModuleAdminController
      */
     public function getCustomerColumnValue($customerName, array $row)
     {
-        if (empty($row['id_customer'])) {
+        if ((int) ($row['id_customer'] ?? 0) === 0) {
             return $customerName;
         }
         $customerLink = $this->getModule()->getAdminLink('AdminCustomers', ['id_customer' => $row['id_customer'], 'viewcustomer' => true]);

--- a/packetery/libs/ApiCarrier/ApiCarrierRepository.php
+++ b/packetery/libs/ApiCarrier/ApiCarrierRepository.php
@@ -330,7 +330,7 @@ class ApiCarrierRepository
             'SELECT 1
             FROM `' . $this->getPrefixedTableName() . '`
             WHERE `is_pickup_points` = 1
-            AND `id` = "' . $this->dbTools->db->escape($carrierId) . '"'
+            AND `id` = "' . $this->dbTools->db->escape((string) $carrierId) . '"'
         );
 
         return (int) $result === 1;

--- a/packetery/libs/Carrier/CarrierTools.php
+++ b/packetery/libs/Carrier/CarrierTools.php
@@ -48,7 +48,7 @@ class CarrierTools
         foreach ($carrierZones as $carrierZone) {
             $zoneCountries = Country::getCountriesByZoneId(
                 $carrierZone['id_zone'],
-                Configuration::get('PS_LANG_DEFAULT')
+                (int) Configuration::get('PS_LANG_DEFAULT')
             );
             foreach ($zoneCountries as $zoneCountry) {
                 if ($zoneCountry['active']) {

--- a/packetery/libs/Hooks/ActionValidateStepComplete.php
+++ b/packetery/libs/Hooks/ActionValidateStepComplete.php
@@ -55,7 +55,7 @@ class ActionValidateStepComplete
      */
     public function execute(array &$params): ?string
     {
-        if (empty($params['cart'])) {
+        if (!isset($params['cart'])) {
             \PrestaShopLogger::addLog('Cart is not present in hook parameters.', 3, null, null, null, true);
             $params['completed'] = false;
 
@@ -71,7 +71,7 @@ class ActionValidateStepComplete
         $isExternalPickupPointCarrier = $this->apiCarrierRepository->isExternalPickupPointCarrier((int) $packeteryCarrier['id_branch']);
         $isPickupPointCarrier = $this->isPickupPointCarrier($isExternalPickupPointCarrier, (string) $packeteryCarrier['id_branch']);
 
-        if ($isPickupPointCarrier === true && empty($orderData['id_branch'])) {
+        if ($isPickupPointCarrier === true && (int) ($orderData['id_branch'] ?? 0) === 0) {
             $params['completed'] = false;
 
             return $this->module->l('Please select pickup point.', 'actionvalidatestepcomplete');

--- a/packetery/libs/Module/Installer.php
+++ b/packetery/libs/Module/Installer.php
@@ -104,6 +104,7 @@ class Installer
             ],
         ];
 
+        $result = true;
         try {
             foreach ($menuConfig as $menuItem) {
                 $result = $this->addTab($menuItem['parentClass'], $menuItem['class'], $menuItem['name']);

--- a/packetery/libs/Module/SoapApi.php
+++ b/packetery/libs/Module/SoapApi.php
@@ -96,7 +96,7 @@ class SoapApi
             // get PacketInfoResult
             $response = $client->packetInfo($this->configHelper->getApiPass(), $packetId);
             if (
-                !empty($response->courierInfo)
+                isset($response->courierInfo)
                 && isset($response->courierInfo->courierInfoItem, $response->courierInfo->courierInfoItem->courierTrackingUrls)
             ) {
                 $packetInfo->setNumber($response->courierInfo->courierInfoItem->courierNumbers->courierNumber);

--- a/packetery/libs/Order/Labels.php
+++ b/packetery/libs/Order/Labels.php
@@ -59,13 +59,13 @@ class Labels
 
         if ($type === self::TYPE_CARRIER) {
             $format = ConfigHelper::get('PACKETERY_CARRIER_LABEL_FORMAT');
-            $response = $soapApi->getPacketsCourierLabelsPdf($packetsEnhanced, $format, $offset);
+            $response = $soapApi->getPacketsCourierLabelsPdf($packetsEnhanced, $format, (string) $offset);
             if ($fallbackToPacketaLabel === true && $response->hasFault()) {
-                $response = $soapApi->getPacketsLabelsPdf(array_values($packets), $format, $offset);
+                $response = $soapApi->getPacketsLabelsPdf(array_values($packets), $format, (string) $offset);
             }
         } else {
             $format = ConfigHelper::get('PACKETERY_LABEL_FORMAT');
-            $response = $soapApi->getPacketsLabelsPdf(array_values($packets), $format, $offset);
+            $response = $soapApi->getPacketsLabelsPdf(array_values($packets), $format, (string) $offset);
         }
 
         if ($response->hasFault()) {

--- a/packetery/libs/Order/OrderExporter.php
+++ b/packetery/libs/Order/OrderExporter.php
@@ -48,7 +48,7 @@ class OrderExporter
         $orderRepository = $this->module->diContainer->get(OrderRepository::class);
         $packeteryOrder = $orderRepository->getWithShopById($order->id);
 
-        if (empty($packeteryOrder) || empty($packeteryOrder['id_branch'])) {
+        if (!is_array($packeteryOrder) || (int) ($packeteryOrder['id_branch'] ?? 0) === 0) {
             throw new ExportException($this->module->l('Unable to load information required to export order', 'orderexporter') . ' ' . $order->id);
         }
 

--- a/packetery/libs/Order/OrderSaver.php
+++ b/packetery/libs/Order/OrderSaver.php
@@ -95,7 +95,7 @@ class OrderSaver
                 !$hasExistingSameCarrier
                 || ((int) $existingOrder['is_ad'] !== 0 && (int) $existingOrder['id_branch'] === (int) $packeteryCarrier['id_branch'])
             ) {
-                $data['id_branch'] = $packeteryCarrier['id_branch'] ?: null;
+                $data['id_branch'] = (bool) $packeteryCarrier['id_branch'] ? $packeteryCarrier['id_branch'] : null;
                 $data['name_branch'] = $packeteryCarrier['name_branch'];
                 $data['currency_branch'] = $packeteryCarrier['currency_branch'];
                 $data['is_ad'] = 1;

--- a/packetery/libs/Order/PacketSubmitter.php
+++ b/packetery/libs/Order/PacketSubmitter.php
@@ -95,7 +95,7 @@ class PacketSubmitter
         }
 
         foreach (['carrierPickupPoint', 'street', 'houseNumber', 'city', 'zip'] as $key) {
-            if (!empty($exportData[$key])) {
+            if ((bool) ($exportData[$key] ?? null)) {
                 $packetAttributes[$key] = $exportData[$key];
             }
         }

--- a/packetery/libs/PacketTracking/PacketTrackingCron.php
+++ b/packetery/libs/PacketTracking/PacketTrackingCron.php
@@ -101,7 +101,7 @@ class PacketTrackingCron
         $orders = $this->orderRepository->getOrdersByStateAndLastUpdate(
             $enabledOrderStatuses,
             $finalStatusIds,
-            ConfigHelper::get('PACKETERY_PACKET_STATUS_TRACKING_MAX_PROCESSED_ORDERS'),
+            (int) ConfigHelper::get('PACKETERY_PACKET_STATUS_TRACKING_MAX_PROCESSED_ORDERS'),
             $oldestOrderDate
         );
 
@@ -220,7 +220,7 @@ class PacketTrackingCron
             return;
         }
 
-        $orderState = new \OrderState($newOrderStatus);
+        $orderState = new \OrderState((int) $newOrderStatus);
         $isOrderStateExists = Validate::isLoadedObject($orderState);
         if ($isOrderStateExists === false) {
             return;

--- a/packetery/libs/Tools/ConfigHelper.php
+++ b/packetery/libs/Tools/ConfigHelper.php
@@ -139,7 +139,7 @@ class ConfigHelper
     {
         $employee = $module->getContext()->employee;
 
-        return \Language::getIsoById($employee ? $employee->id_lang : \Configuration::get('PS_LANG_DEFAULT'));
+        return \Language::getIsoById($employee !== null ? $employee->id_lang : \Configuration::get('PS_LANG_DEFAULT'));
     }
 
     /**

--- a/packetery/libs/Tools/DbTools.php
+++ b/packetery/libs/Tools/DbTools.php
@@ -70,7 +70,7 @@ class DbTools
             throw new DatabaseException($exception->getMessage() . ', see details in Packeta log');
         }
         $error = $this->db->getNumberError();
-        if ($error) {
+        if ($error !== 0) {
             $this->logger->logToFile($this->db->getMsgError() . ', query: ' . $query);
             throw new DatabaseException($this->db->getMsgError() . ', see details in Packeta log');
         }
@@ -85,6 +85,7 @@ class DbTools
      */
     public function getRows($sql)
     {
+        $result = null;
         try {
             $result = $this->db->executeS($sql);
         } catch (\PrestaShopException $exception) {
@@ -104,6 +105,7 @@ class DbTools
      */
     public function getRow($sql)
     {
+        $result = null;
         try {
             $result = $this->db->getRow($sql);
         } catch (\PrestaShopException $exception) {
@@ -143,6 +145,7 @@ class DbTools
      */
     public function execute($sql, $useCache = true)
     {
+        $result = false;
         try {
             $result = $this->db->execute($sql, $useCache);
         } catch (\PrestaShopException $exception) {
@@ -167,6 +170,7 @@ class DbTools
     public function delete($table, $where = '', $limit = 0, $useCache = true, $addPrefix = true)
     {
         $queryForLog = 'table ' . $table . '; where ' . $where;
+        $result = false;
         try {
             $result = $this->db->delete($table, $where, $limit, $useCache, $addPrefix);
         } catch (\PrestaShopException $exception) {
@@ -180,7 +184,7 @@ class DbTools
     /**
      * @param string $table
      * @param array $data
-     * @param false $nullValues
+     * @param bool $nullValues
      * @param bool $useCache
      * @param int $type
      * @param bool $addPrefix
@@ -192,6 +196,7 @@ class DbTools
     public function insert($table, $data, $nullValues = false, $useCache = true, $type = \Db::INSERT, $addPrefix = true)
     {
         $queryForLog = 'table ' . $table . '; data ' . json_encode($data);
+        $result = false;
         try {
             $result = $this->db->insert($table, $data, $nullValues, $useCache, $type, $addPrefix);
         } catch (\PrestaShopException $exception) {
@@ -207,7 +212,7 @@ class DbTools
      * @param array $data
      * @param string $where
      * @param int $limit
-     * @param false $nullValues
+     * @param bool $nullValues
      * @param bool $useCache
      * @param bool $addPrefix
      *
@@ -218,6 +223,7 @@ class DbTools
     public function update($table, $data, $where = '', $limit = 0, $nullValues = false, $useCache = true, $addPrefix = true)
     {
         $queryForLog = 'table ' . $table . '; data ' . json_encode($data) . '; where ' . $where;
+        $result = false;
         try {
             $result = $this->db->update($table, $data, $where, $limit, $nullValues, $useCache, $addPrefix);
         } catch (\PrestaShopException $exception) {

--- a/packetery/libs/Tools/Tools.php
+++ b/packetery/libs/Tools/Tools.php
@@ -31,7 +31,7 @@ class Tools extends \ToolsCore
         // otherwise, it's sometimes not possible to decode JSON got in POST
         if (PrestaShopTools::version_compare(_PS_VERSION_, '1.7.6', '<')) {
             // version from PrestaShop 1.7.6
-            if (empty($key) || !is_string($key)) {
+            if ($key === '' || $key === '0' || !is_string($key)) {
                 return false;
             }
 

--- a/packetery/packetery.php
+++ b/packetery/packetery.php
@@ -153,7 +153,7 @@ class Packetery extends CarrierModule
      */
     public function hookActionCarrierUpdate(array $params)
     {
-        if ($params['id_carrier'] != $params['carrier']->id) {
+        if ((int) $params['id_carrier'] !== (int) $params['carrier']->id) {
             $carrierRepository = $this->diContainer->get(Packetery\Carrier\CarrierRepository::class);
             $carrierRepository->swapId((int) $params['id_carrier'], (int) $params['carrier']->id);
         }
@@ -774,7 +774,7 @@ class Packetery extends CarrierModule
         $customerStreet = '';
         $customerCity = '';
         $customerZip = '';
-        if (isset($cart->id_address_delivery) && !empty($cart->id_address_delivery)) {
+        if ((int) ($cart->id_address_delivery ?? 0) !== 0) {
             $address = new AddressCore($cart->id_address_delivery);
             $customerStreet = trim($address->address1);
             $customerCity = trim($address->city);
@@ -798,7 +798,7 @@ class Packetery extends CarrierModule
         $this->context->smarty->assign('widget_vendors', json_encode($widgetVendors));
 
         $orderData = null;
-        if (!empty($cart) && ($packeteryCarrier['pickup_point_type'] !== null || $packeteryCarrier['address_validation'] !== 'none')) {
+        if ($cart !== null && ($packeteryCarrier['pickup_point_type'] !== null || $packeteryCarrier['address_validation'] !== 'none')) {
             $orderRepository = $this->diContainer->get(Packetery\Order\OrderRepository::class);
             $orderData = $orderRepository->getByCartAndCarrier((int) $cart->id, (int) $id_carrier);
         }
@@ -919,7 +919,7 @@ class Packetery extends CarrierModule
 
         /* Get language from cart, global $language updates weirdly */
         $language = new LanguageCore($cart->id_lang);
-        $shopLanguage = $language->iso_code ?: 'en';
+        $shopLanguage = ($language->iso_code === null || $language->iso_code === '') ? 'en' : $language->iso_code;
         $shopLanguage = strtolower($shopLanguage);
 
         $isPS16 = strpos(_PS_VERSION_, '1.6') === 0;
@@ -1118,10 +1118,13 @@ class Packetery extends CarrierModule
 
         $isExported = (bool) $packeteryOrder['exported'];
         if ($isExported === false) {
+            $submittedLength = Tools::getValue('length');
+            $submittedHeight = Tools::getValue('height');
+            $submittedWidth = Tools::getValue('width');
             $orderDetails = [
-                'length' => Tools::getValue('length') ?: $packeteryOrder['length'],
-                'height' => Tools::getValue('height') ?: $packeteryOrder['height'],
-                'width' => Tools::getValue('width') ?: $packeteryOrder['width'],
+                'length' => (bool) $submittedLength ? $submittedLength : $packeteryOrder['length'],
+                'height' => (bool) $submittedHeight ? $submittedHeight : $packeteryOrder['height'],
+                'width' => (bool) $submittedWidth ? $submittedWidth : $packeteryOrder['width'],
             ];
             $this->context->smarty->assign('orderDetails', $orderDetails);
         }
@@ -1347,12 +1350,12 @@ class Packetery extends CarrierModule
         $carrierRepository = $this->diContainer->get(Packetery\Carrier\CarrierRepository::class);
 
         $packeteryOrder = $orderRepository->getById($orderId);
-        if (empty($packeteryOrder)) {
+        if (!is_array($packeteryOrder) || $packeteryOrder === []) {
             return [];
         }
 
         $packeteryCarrier = $carrierRepository->getPacketeryCarrierById($packeteryOrder['id_carrier']);
-        if (empty($packeteryCarrier)) {
+        if (!is_array($packeteryCarrier) || $packeteryCarrier === []) {
             return [];
         }
 

--- a/phpstan/phpstan-baseline.neon
+++ b/phpstan/phpstan-baseline.neon
@@ -1,12 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 2
-			path: ../packetery/controllers/admin/PacketeryCarrierGridController.php
-
-		-
 			message: '#^Only booleans are allowed in an if condition, array\|null given\.$#'
 			identifier: if.condNotBoolean
 			count: 1
@@ -22,12 +16,6 @@ parameters:
 			message: '#^Access to property \$id on an unknown class InstallLanguage\.$#'
 			identifier: class.notFound
 			count: 2
-			path: ../packetery/controllers/admin/PacketeryOrderGridController.php
-
-		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 3
 			path: ../packetery/controllers/admin/PacketeryOrderGridController.php
 
 		-
@@ -73,12 +61,6 @@ parameters:
 			path: ../packetery/libs/AbstractFormService.php
 
 		-
-			message: '#^Parameter \#1 \$string of method DbCore\:\:escape\(\) expects string, int given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../packetery/libs/ApiCarrier/ApiCarrierRepository.php
-
-		-
 			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
 			identifier: function.strict
 			count: 2
@@ -97,18 +79,6 @@ parameters:
 			path: ../packetery/libs/Carrier/CarrierRepository.php
 
 		-
-			message: '#^Parameter \#3 \$nullValues of method Packetery\\Tools\\DbTools\:\:insert\(\) expects false, true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../packetery/libs/Carrier/CarrierRepository.php
-
-		-
-			message: '#^Parameter \#5 \$nullValues of method Packetery\\Tools\\DbTools\:\:update\(\) expects false, true given\.$#'
-			identifier: argument.type
-			count: 2
-			path: ../packetery/libs/Carrier/CarrierRepository.php
-
-		-
 			message: '#^Call to an undefined static method Carrier\:\:getCarrierNameFromShopName\(\)\.$#'
 			identifier: staticMethod.notFound
 			count: 1
@@ -117,12 +87,6 @@ parameters:
 		-
 			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
 			identifier: function.strict
-			count: 1
-			path: ../packetery/libs/Carrier/CarrierTools.php
-
-		-
-			message: '#^Parameter \#2 \$idLang of static method CountryCore\:\:getCountriesByZoneId\(\) expects int, string\|false given\.$#'
-			identifier: argument.type
 			count: 1
 			path: ../packetery/libs/Carrier/CarrierTools.php
 
@@ -139,20 +103,8 @@ parameters:
 			path: ../packetery/libs/Hooks/ActionObjectOrderUpdateBefore.php
 
 		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 2
-			path: ../packetery/libs/Hooks/ActionValidateStepComplete.php
-
-		-
 			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
 			identifier: function.strict
-			count: 1
-			path: ../packetery/libs/Module/Installer.php
-
-		-
-			message: '#^Variable \$result might not be defined\.$#'
-			identifier: variable.undefined
 			count: 1
 			path: ../packetery/libs/Module/Installer.php
 
@@ -163,28 +115,10 @@ parameters:
 			path: ../packetery/libs/Module/Options.php
 
 		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 1
-			path: ../packetery/libs/Module/SoapApi.php
-
-		-
 			message: '#^Only booleans are allowed in a negated boolean, string\|null given\.$#'
 			identifier: booleanNot.exprNotBoolean
 			count: 1
 			path: ../packetery/libs/Module/VersionChecker.php
-
-		-
-			message: '#^Parameter \#3 \$offset of method Packetery\\Module\\SoapApi\:\:getPacketsCourierLabelsPdf\(\) expects string, int given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../packetery/libs/Order/Labels.php
-
-		-
-			message: '#^Parameter \#3 \$offset of method Packetery\\Module\\SoapApi\:\:getPacketsLabelsPdf\(\) expects string, int given\.$#'
-			identifier: argument.type
-			count: 2
-			path: ../packetery/libs/Order/Labels.php
 
 		-
 			message: '#^Only booleans are allowed in a negated boolean, mixed given\.$#'
@@ -193,58 +127,16 @@ parameters:
 			path: ../packetery/libs/Order/OrderDetailsUpdater.php
 
 		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 2
-			path: ../packetery/libs/Order/OrderExporter.php
-
-		-
 			message: '#^Only booleans are allowed in a negated boolean, float\|null given\.$#'
 			identifier: booleanNot.exprNotBoolean
 			count: 1
 			path: ../packetery/libs/Order/OrderExporter.php
 
 		-
-			message: '#^Parameter \#3 \$nullValues of method Packetery\\Tools\\DbTools\:\:insert\(\) expects false, bool given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../packetery/libs/Order/OrderRepository.php
-
-		-
-			message: '#^Parameter \#3 \$nullValues of method Packetery\\Tools\\DbTools\:\:insert\(\) expects false, true given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../packetery/libs/Order/OrderRepository.php
-
-		-
-			message: '#^Parameter \#5 \$nullValues of method Packetery\\Tools\\DbTools\:\:update\(\) expects false, bool given\.$#'
-			identifier: argument.type
-			count: 2
-			path: ../packetery/libs/Order/OrderRepository.php
-
-		-
-			message: '#^Parameter \#5 \$nullValues of method Packetery\\Tools\\DbTools\:\:update\(\) expects false, true given\.$#'
-			identifier: argument.type
-			count: 4
-			path: ../packetery/libs/Order/OrderRepository.php
-
-		-
 			message: '#^Only booleans are allowed in an if condition, string given\.$#'
 			identifier: if.condNotBoolean
 			count: 1
 			path: ../packetery/libs/Order/OrderSaver.php
-
-		-
-			message: '#^Short ternary operator is not allowed\. Use null coalesce operator if applicable or consider using long ternary\.$#'
-			identifier: ternary.shortNotAllowed
-			count: 1
-			path: ../packetery/libs/Order/OrderSaver.php
-
-		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 1
-			path: ../packetery/libs/Order/PacketSubmitter.php
 
 		-
 			message: '#^Only booleans are allowed in a negated boolean, array given\.$#'
@@ -261,18 +153,6 @@ parameters:
 		-
 			message: '#^PHPDoc tag @var with type stdClass is not subtype of type array\.$#'
 			identifier: varTag.type
-			count: 1
-			path: ../packetery/libs/PacketTracking/PacketTrackingCron.php
-
-		-
-			message: '#^Parameter \#1 \$id of class OrderState constructor expects int\|null, string\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../packetery/libs/PacketTracking/PacketTrackingCron.php
-
-		-
-			message: '#^Parameter \#3 \$maxProcessedOrdersLimit of method Packetery\\Order\\OrderRepository\:\:getOrdersByStateAndLastUpdate\(\) expects int, string\|false given\.$#'
-			identifier: argument.type
 			count: 1
 			path: ../packetery/libs/PacketTracking/PacketTrackingCron.php
 
@@ -295,12 +175,6 @@ parameters:
 			path: ../packetery/libs/PickupPointValidate/ValidatedPoint.php
 
 		-
-			message: '#^Only booleans are allowed in a ternary operator condition, Employee\|null given\.$#'
-			identifier: ternary.condNotBoolean
-			count: 1
-			path: ../packetery/libs/Tools/ConfigHelper.php
-
-		-
 			message: '#^Call to an undefined method ControllerCore\:\:registerJavascript\(\)\.$#'
 			identifier: method.notFound
 			count: 1
@@ -317,24 +191,6 @@ parameters:
 			identifier: if.condNotBoolean
 			count: 2
 			path: ../packetery/libs/Tools/ControllerWrapper.php
-
-		-
-			message: '#^Only booleans are allowed in an if condition, int given\.$#'
-			identifier: if.condNotBoolean
-			count: 1
-			path: ../packetery/libs/Tools/DbTools.php
-
-		-
-			message: '#^Variable \$result might not be defined\.$#'
-			identifier: variable.undefined
-			count: 6
-			path: ../packetery/libs/Tools/DbTools.php
-
-		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 1
-			path: ../packetery/libs/Tools/Tools.php
 
 		-
 			message: '#^Only booleans are allowed in an if condition, mixed given\.$#'
@@ -373,18 +229,6 @@ parameters:
 			path: ../packetery/packetery.php
 
 		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 4
-			path: ../packetery/packetery.php
-
-		-
-			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
-			identifier: notEqual.notAllowed
-			count: 1
-			path: ../packetery/packetery.php
-
-		-
 			message: '#^Only booleans are allowed in an if condition, mixed given\.$#'
 			identifier: if.condNotBoolean
 			count: 4
@@ -400,12 +244,6 @@ parameters:
 			message: '#^Parameter \#1 \$widgetOptions of method Packetery\:\:getValidWidgetOptions\(\) expects array\<string, int\|string\>, array\<string, array\|string\|false\> given\.$#'
 			identifier: argument.type
 			count: 1
-			path: ../packetery/packetery.php
-
-		-
-			message: '#^Short ternary operator is not allowed\. Use null coalesce operator if applicable or consider using long ternary\.$#'
-			identifier: ternary.shortNotAllowed
-			count: 4
 			path: ../packetery/packetery.php
 
 		-


### PR DESCRIPTION
**WIP / draft** — bez Jira ticketu (bude doplněn).

## Co
Odpárání chyb z `phpstan/phpstan-baseline.neon`, které jdou opravit přímo v kódu **bez změny chování**, místo aby zůstaly potlačené v baselině.

## Výsledek
- Baseline **108 → 59 chyb** (71 → 44 záznamů), 49 oprav napříč 16 soubory.
- Opravené kategorie: `variable.undefined` (init `$result`), `empty.notAllowed` (explicitní porovnání), `ternary.shortNotAllowed` (dlouhý ternár), `argument.type` (casty + oprava chybné `@param false`→`bool` v `DbTools`), `notEqual`, `ternary.condNotBoolean`, pure-int `if`.
- Vědomě ponecháno v baselině: `function.strict` (in_array — PHP<8 konvence), stub/env nálezy (`class/method.notFound`, `constant.notFound`), judgment `if/booleanNot.condNotBoolean`.

## Ověření
- PHPStan `[OK]` na PHP 8.3 i 8.5; `php -l` celého modulu na 7.3 i 8.5.
- `composer check:all` (ec + phpcs + phpcsfixer + phpstan) zelené.
- validator.prestashop.com: 0 blokujících Errors (jen pre-existing `nofilter` + kosmetika).
- div-by-zero nález v `PaymentRepository` out-of-scope