### PR TITLE
PES-3288: add admin media only once per request

### DIFF
--- a/packetery/packetery.php
+++ b/packetery/packetery.php
@@ -65,6 +65,9 @@ class Packetery extends CarrierModule
 
     protected $config_form = false;
 
+    /** @var bool guards hookActionAdminControllerSetMedia against a second run in the same request */
+    private static $adminMediaAdded = false;
+
     /** @var Packetery\DI\Container */
     public $diContainer;
 
@@ -1449,9 +1452,23 @@ class Packetery extends CarrierModule
 
     /**
      * hook used everywhere in administration
+     *
+     * PS 9 runs this hook twice on legacy controllers: once from AdminController::setMedia(),
+     * once from the HeadTag Twig component
      */
     public function hookActionAdminControllerSetMedia()
     {
+        $this->addAdminMediaOnce();
+    }
+
+    private function addAdminMediaOnce(): void
+    {
+        if (self::$adminMediaAdded === true) {
+            return;
+        }
+
+        self::$adminMediaAdded = true;
+
         $suffix = '?v=' . $this->version;
         if (Tools::version_compare(_PS_VERSION_, '1.7.0.0', '<')) {
             $suffix = '';


### PR DESCRIPTION
[https://packeta.atlassian.net/browse/PES-3288](https://packeta.atlassian.net/browse/PES-3288)

- PS 9 vyvolává akci `actionAdminControllerSetMedia` dvakrát u starších controllers – jednou z metody `AdminController::setMedia()` a jednou z komponenty Twig `HeadTag`.
- Tím se soubor `back.js` načítal dvakrát, včetně duplicitního napojení handlerů.
- To způsobilo bug, že např. akce vracení v seznamu objednávek Packeta vyžadovaly potvrzení dvakrát (PES-3252)
- Ochranný mechanismus se vztahuje pouze na registraci, nikoli na hook, takže cokoli, co bylo přidáno později a vykresluje aktuální stav, se může stále spouštět při každém průchodu.

- Pozn. v novjěší verzi v3.6 bude metoda přesunuta jinam, ochrana se nesmí zapomenout
- Test proti všem stackům
