### PR TITLE
PES-3291: Fix double confirm dialog on returns actions (PS 9)

### DIFF
--- a/packetery/libs/Hooks/ActionAdminControllerSetMedia.php
+++ b/packetery/libs/Hooks/ActionAdminControllerSetMedia.php
@@ -29,6 +29,9 @@ class ActionAdminControllerSetMedia
     /** @var string|null */
     private $renderedNotice;
 
+    /** @var bool */
+    private $mediaAdded = false;
+
     public function __construct(
         \Packetery $module,
         VersionChecker $versionChecker,
@@ -41,30 +44,44 @@ class ActionAdminControllerSetMedia
 
     /**
      * PrestaShop 9 fires this hook twice per admin page - before the page action and again while the
-     * page is rendered - so everything here has to survive being called repeatedly.
+     * page is rendered. Assets must be added once (see addMedia), the notice must refresh on every call.
      *
      * @throws \Packetery\Exceptions\DatabaseException
      */
     public function execute(): void
     {
-        $suffix = "?v={$this->module->version}";
-        if (\Tools::version_compare(_PS_VERSION_, '1.7.0.0', '<') === true) {
-            $suffix = '';
-        }
-
         // On PrestaShop 9 the controller is an AdminController on legacy pages but a LegacyControllerContext
         // on migrated ones; both carry the addCSS/addJS/$warnings API, so never type-hint against either.
         /** @var \AdminController $controller */
         $controller = $this->module->getContext()->controller;
 
+        $this->addMedia($controller);
+        $this->versionChecker->checkForUpdate();
+        $this->refreshPendingReturnsNotice($controller);
+    }
+
+    /**
+     * On the second call addCSS would deduplicate by its versioned uri but addJS would not, so back.js
+     * would load twice and bind the a[data-confirm] handler twice (double confirm dialog) - hence the guard.
+     *
+     * @param \AdminController $controller on pages migrated to Symfony it is a LegacyControllerContext instead
+     */
+    private function addMedia($controller): void
+    {
+        if ($this->mediaAdded === true) {
+            return;
+        }
+        $this->mediaAdded = true;
+
+        $suffix = "?v={$this->module->version}";
+        if (\Tools::version_compare(_PS_VERSION_, '1.7.0.0', '<') === true) {
+            $suffix = '';
+        }
+
         $pathUri = $this->module->getPathUri();
         $controller->addCSS("{$pathUri}views/css/back.css{$suffix}", 'all', null, false);
         $controller->addJS("{$pathUri}views/js/stringyfyOptions.js{$suffix}");
         $controller->addJS("{$pathUri}views/js/back.js{$suffix}");
-
-        $this->versionChecker->checkForUpdate();
-
-        $this->refreshPendingReturnsNotice($controller);
     }
 
     /**

--- a/tests/Unit/Hooks/ActionAdminControllerSetMediaTest.php
+++ b/tests/Unit/Hooks/ActionAdminControllerSetMediaTest.php
@@ -82,11 +82,12 @@ class ActionAdminControllerSetMediaTest extends TestCase
         $this->assertSame([self::FOREIGN_WARNING, self::NOTICE_HTML_UPDATED], $controller->warnings);
     }
 
-    public function testRegistersTheModuleAssetsOnEveryRun(): void
+    public function testRegistersTheModuleAssetsOnlyOnceAcrossRepeatedRuns(): void
     {
         $controller = $this->createController();
-        $hook = $this->createHook($controller, [], [null]);
+        $hook = $this->createHook($controller, [], [null, null]);
 
+        $hook->execute();
         $hook->execute();
 
         $this->assertCount(1, $controller->cssFiles);


### PR DESCRIPTION
Story PES-3291 (relates PES-3288) — https://packeta.atlassian.net/browse/PES-3291

Na PrestaShopu 9 se u akcí s vratkou zobrazoval potvrzovací dialog **dvakrát**. PS 9 pouští
`actionAdminControllerSetMedia` 2× za request; `addCSS` deduplikuje podle verzované uri, ale
`addJS` ne → `back.js` se načte dvakrát a handler `a[data-confirm]` se naváže 2×.

Root bug je opraven ve `v3.5` (PES-3288); do `v3.6` inline fix nesedí — hook je tu vyextrahovaný
do `Packetery\Hooks\ActionAdminControllerSetMedia`, takže guard je reimplementován v té třídě.
Guard obaluje **jen registraci assetů** (`addMedia()`), ne celý hook — `refreshPendingReturnsNotice()`
musí dál běžet na každém volání (notifikace z PES-3277).
