### PR TITLE
PES-3292: Mandatory GDPR consent on customer return forms

### DIFF
--- a/packetery/controllers/front/return.php
+++ b/packetery/controllers/front/return.php
@@ -14,6 +14,7 @@ use Packetery\Address\AddressTools;
 use Packetery\Order\ClaimSubmitter;
 use Packetery\Order\ReturnSubmissionResult;
 use Packetery\Returns\CustomerReturnSectionProvider;
+use Packetery\Returns\ReturnConsentProvider;
 use Packetery\Returns\ReturnEntity;
 
 /**
@@ -109,6 +110,13 @@ class PacketeryReturnModuleFrontController extends ModuleFrontController
                 return;
             }
 
+            // legal consent is mandatory: without it no return is created, not even a pending one
+            if (!$this->isConsentGiven()) {
+                $this->redirectToOrderDetail($orderId, 'consent');
+
+                return;
+            }
+
             $result = $this->createReturn($orderId);
         } catch (Exception $exception) {
             $this->redirectToOrderDetail($orderId, 'error');
@@ -175,11 +183,16 @@ class PacketeryReturnModuleFrontController extends ModuleFrontController
 
             // create only from the form state (eligible, no active return); guards a duplicate on re-POST
             if ($this->guestCreateAttempted && $section['returnState'] === CustomerReturnSectionProvider::STATE_FORM) {
-                $result = $this->createReturn($orderId);
-                if ($result->isError()) {
-                    $this->guestError = $this->getModule()->l('The return could not be created. Please check your e-mail and phone number and try again, or contact the e-shop.', 'return');
+                // legal consent is mandatory: without it no return is created, not even a pending one
+                if (!$this->isConsentGiven()) {
+                    $this->guestError = $this->getModule()->l('You must agree to the Terms of Service and the Privacy Policy to create a return.', 'return');
                 } else {
-                    $this->guestJustCreated = true;
+                    $result = $this->createReturn($orderId);
+                    if ($result->isError()) {
+                        $this->guestError = $this->getModule()->l('The return could not be created. Please check your e-mail and phone number and try again, or contact the e-shop.', 'return');
+                    } else {
+                        $this->guestJustCreated = true;
+                    }
                 }
                 $section = $this->buildSection($orderId);
             }
@@ -223,6 +236,10 @@ class PacketeryReturnModuleFrontController extends ModuleFrontController
 
     private function assignGuestView(): void
     {
+        /** @var ReturnConsentProvider $consentProvider */
+        $consentProvider = $this->getModule()->diContainer->get(ReturnConsentProvider::class);
+        $iso = $this->currentLanguageIso();
+
         $this->context->smarty->assign([
             'guestView' => $this->guestView,
             'guestError' => $this->guestError,
@@ -235,6 +252,8 @@ class PacketeryReturnModuleFrontController extends ModuleFrontController
             'guestCreateAttempted' => $this->guestCreateAttempted,
             'returnActionUrl' => $this->context->link->getModuleLink(Packetery::MODULE_SLUG, 'return'),
             'returnToken' => Tools::getToken(false),
+            'consentTermsTag' => $consentProvider->getTermsLinkOpenTag($iso),
+            'consentPrivacyTag' => $consentProvider->getPrivacyPolicyLinkOpenTag($iso),
         ]);
     }
 
@@ -261,9 +280,24 @@ class PacketeryReturnModuleFrontController extends ModuleFrontController
     {
         $email = trim((string) Tools::getValue('packetery_email'));
         $phone = trim((string) Tools::getValue('packetery_phone'));
+        // captured here, at consent time: creating the return can lag (Packeta API call, or e-shop approval)
+        $consentGivenAt = (new DateTimeImmutable('now'))->format('Y-m-d H:i:s');
 
         return $this->getModule()->diContainer->get(ClaimSubmitter::class)
-            ->submit($orderId, ReturnEntity::SOURCE_CUSTOMER, $email, $phone);
+            ->submit($orderId, ReturnEntity::SOURCE_CUSTOMER, $email, $phone, $consentGivenAt, $this->currentLanguageIso());
+    }
+
+    private function isConsentGiven(): bool
+    {
+        return (bool) Tools::getValue('packetery_return_consent');
+    }
+
+    private function currentLanguageIso(): string
+    {
+        /** @var Language $language */
+        $language = $this->context->language;
+
+        return (string) $language->iso_code;
     }
 
     /**
@@ -308,7 +342,7 @@ class PacketeryReturnModuleFrontController extends ModuleFrontController
     }
 
     /**
-     * @param string|null $status 'created', 'pending', 'exists', 'error', or null (shown as a flash in the order detail)
+     * @param string|null $status 'created', 'pending', 'exists', 'consent', 'error', or null (shown as a flash in the order detail)
      *
      * @throws PrestaShopException
      */

--- a/packetery/libs/Order/ClaimSubmitter.php
+++ b/packetery/libs/Order/ClaimSubmitter.php
@@ -47,27 +47,38 @@ class ClaimSubmitter
      * @param string $source ReturnEntity::SOURCE_ADMIN or ReturnEntity::SOURCE_CUSTOMER
      * @param string|null $email contact override from the customer return form (null = use the order)
      * @param string|null $phone contact override from the customer return form (null = use the order)
+     * @param string|null $consentGivenAt when the customer confirmed the consent (customer flow only),
+     *                                    as 'Y-m-d H:i:s'; captured at form submission, not at insert
+     * @param string|null $consentLanguage ISO code the customer confirmed the consent in (customer flow only)
      *
      * @throws DatabaseException
      */
-    public function submit(int $orderId, string $source, ?string $email = null, ?string $phone = null): ReturnSubmissionResult
-    {
+    public function submit(
+        int $orderId,
+        string $source,
+        ?string $email = null,
+        ?string $phone = null,
+        ?string $consentGivenAt = null,
+        ?string $consentLanguage = null
+    ): ReturnSubmissionResult {
         if ($source === ReturnEntity::SOURCE_CUSTOMER && $this->approvalPolicy->needsApproval($orderId)) {
             // not sent to Packeta yet; keep the entered contact so approval can build the claim from it
-            $this->returnRepository->insertPending($orderId, $source, $email, $phone);
+            $this->returnRepository->insertPending($orderId, $source, $email, $phone, $consentGivenAt, $consentLanguage);
 
             return ReturnSubmissionResult::pending();
         }
 
         $response = $this->apiSender->send($orderId, $email, $phone);
 
-        return ClaimApiSender::finalize($response, function () use ($orderId, $response, $source): void {
+        return ClaimApiSender::finalize($response, function () use ($orderId, $response, $source, $consentGivenAt, $consentLanguage): void {
             $this->returnRepository->insert(
                 $orderId,
                 (string) $response->getId(),
                 $response->getPassword(),
                 ReturnEntity::STATUS_CREATED,
-                $source
+                $source,
+                $consentGivenAt,
+                $consentLanguage
             );
         });
     }

--- a/packetery/libs/Returns/ReturnConsentProvider.php
+++ b/packetery/libs/Returns/ReturnConsentProvider.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * @author    Packeta s.r.o. <e-commerce.support@packeta.com>
+ * @copyright 2015-2026 Packeta s.r.o.
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Packetery\Returns;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * Supplies the Terms of Service and Privacy Policy URLs shown next to the return consent checkbox,
+ * chosen by the customer's language.
+ */
+class ReturnConsentProvider
+{
+    private const PRIVACY_URL_BY_ISO = [
+        'cs' => 'https://files.packeta.com/web/files/GDPR.pdf',
+        'sk' => 'https://files.packeta.com/web/files/sk/SK_Zasady-ochrany-osobnych-udajov-od-01-08-2024.pdf',
+        'en' => 'https://files.packeta.com/web/files/Zasilkovna_Privacy-Policy.pdf',
+    ];
+
+    private const TERMS_URL_BY_ISO = [
+        'cs' => 'https://files.packeta.com/web/files/VOP_Zasilkovna.pdf',
+        'sk' => 'https://files.packeta.com/web/files/SK_Obchodne_podmienky_e-shopy_01_07_2026.pdf',
+        'en' => 'https://files.packeta.com/web/files/GTC_Zasilkovna.pdf',
+    ];
+
+    public function getPrivacyPolicyUrl(string $iso): string
+    {
+        return self::PRIVACY_URL_BY_ISO[$iso] ?? self::PRIVACY_URL_BY_ISO['en'];
+    }
+
+    public function getTermsUrl(string $iso): string
+    {
+        return self::TERMS_URL_BY_ISO[$iso] ?? self::TERMS_URL_BY_ISO['en'];
+    }
+
+    /**
+     * Opening <a> tag for the Terms of Service link, ready for the consent sentence's PS `tags` param.
+     * Built here (not interpolated in the .tpl) so the {l} line stays free of {$...} — otherwise the
+     * translation extractor stops at the brace and misses the string.
+     */
+    public function getTermsLinkOpenTag(string $iso): string
+    {
+        return $this->linkOpenTag($this->getTermsUrl($iso));
+    }
+
+    public function getPrivacyPolicyLinkOpenTag(string $iso): string
+    {
+        return $this->linkOpenTag($this->getPrivacyPolicyUrl($iso));
+    }
+
+    private function linkOpenTag(string $url): string
+    {
+        return '<a href="' . htmlspecialchars($url, ENT_QUOTES) . '" target="_blank" rel="noopener noreferrer">';
+    }
+}

--- a/packetery/libs/Returns/ReturnEntity.php
+++ b/packetery/libs/Returns/ReturnEntity.php
@@ -42,6 +42,10 @@ class ReturnEntity
     private $email;
     /** @var string|null */
     private $phone;
+    /** @var string|null */
+    private $consentGivenAt;
+    /** @var string|null */
+    private $consentLanguage;
 
     public function __construct(
         int $idReturn,
@@ -52,7 +56,9 @@ class ReturnEntity
         string $dateAdd,
         ?string $email = null,
         ?string $phone = null,
-        ?string $claimPassword = null
+        ?string $claimPassword = null,
+        ?string $consentGivenAt = null,
+        ?string $consentLanguage = null
     ) {
         $this->idReturn = $idReturn;
         $this->idOrder = $idOrder;
@@ -63,6 +69,8 @@ class ReturnEntity
         $this->email = $email;
         $this->phone = $phone;
         $this->claimPassword = $claimPassword;
+        $this->consentGivenAt = $consentGivenAt;
+        $this->consentLanguage = $consentLanguage;
     }
 
     /**
@@ -81,7 +89,9 @@ class ReturnEntity
             (string) $row['date_add'],
             isset($row['email']) ? (string) $row['email'] : null,
             isset($row['phone']) ? (string) $row['phone'] : null,
-            isset($row['claim_password']) ? (string) $row['claim_password'] : null
+            isset($row['claim_password']) ? (string) $row['claim_password'] : null,
+            isset($row['consent_at']) ? (string) $row['consent_at'] : null,
+            isset($row['consent_language']) ? (string) $row['consent_language'] : null
         );
     }
 
@@ -150,5 +160,23 @@ class ReturnEntity
     public function getPhone(): ?string
     {
         return $this->phone;
+    }
+
+    /**
+     * When the customer confirmed the return consent (checkbox on the return form), captured at form
+     * submission. Null when no customer consent was recorded (e.g. admin-created returns).
+     */
+    public function getConsentGivenAt(): ?string
+    {
+        return $this->consentGivenAt;
+    }
+
+    /**
+     * ISO code of the language the customer confirmed the return consent in. Null when no customer
+     * consent was recorded.
+     */
+    public function getConsentLanguage(): ?string
+    {
+        return $this->consentLanguage;
     }
 }

--- a/packetery/libs/Returns/ReturnRepository.php
+++ b/packetery/libs/Returns/ReturnRepository.php
@@ -36,20 +36,25 @@ class ReturnRepository
         string $claimId,
         ?string $claimPassword,
         string $status,
-        string $source
+        string $source,
+        ?string $consentGivenAt = null,
+        ?string $consentLanguage = null
     ): bool {
         return $this->dbTools->insert(
             self::$tableName,
-            [
-                'id_order' => $idOrder,
-                'claim_id' => $this->dbTools->db->escape($claimId),
-                'claim_password' => $claimPassword === null
-                    ? null
-                    : $this->dbTools->db->escape($claimPassword),
-                'status' => $this->dbTools->db->escape($status),
-                'source' => $this->dbTools->db->escape($source),
-                'date_add' => (new \DateTimeImmutable('now'))->format('Y-m-d H:i:s'),
-            ],
+            array_merge(
+                [
+                    'id_order' => $idOrder,
+                    'claim_id' => $this->dbTools->db->escape($claimId),
+                    'claim_password' => $claimPassword === null
+                        ? null
+                        : $this->dbTools->db->escape($claimPassword),
+                    'status' => $this->dbTools->db->escape($status),
+                    'source' => $this->dbTools->db->escape($source),
+                    'date_add' => (new \DateTimeImmutable('now'))->format('Y-m-d H:i:s'),
+                ],
+                $this->consentColumns($consentGivenAt, $consentLanguage)
+            ),
             true // store a missing claim password as SQL NULL, not ''
         );
     }
@@ -62,22 +67,49 @@ class ReturnRepository
      *
      * @throws DatabaseException
      */
-    public function insertPending(int $idOrder, string $source, ?string $email = null, ?string $phone = null): bool
-    {
+    public function insertPending(
+        int $idOrder,
+        string $source,
+        ?string $email = null,
+        ?string $phone = null,
+        ?string $consentGivenAt = null,
+        ?string $consentLanguage = null
+    ): bool {
         return $this->dbTools->insert(
             self::$tableName,
-            [
-                'id_order' => $idOrder,
-                'claim_id' => null,
-                'claim_password' => null,
-                'status' => $this->dbTools->db->escape(ReturnEntity::STATUS_PENDING),
-                'source' => $this->dbTools->db->escape($source),
-                'date_add' => (new \DateTimeImmutable('now'))->format('Y-m-d H:i:s'),
-                'email' => ($email === null || $email === '') ? null : $this->dbTools->db->escape($email),
-                'phone' => ($phone === null || $phone === '') ? null : $this->dbTools->db->escape($phone),
-            ],
+            array_merge(
+                [
+                    'id_order' => $idOrder,
+                    'claim_id' => null,
+                    'claim_password' => null,
+                    'status' => $this->dbTools->db->escape(ReturnEntity::STATUS_PENDING),
+                    'source' => $this->dbTools->db->escape($source),
+                    'date_add' => (new \DateTimeImmutable('now'))->format('Y-m-d H:i:s'),
+                    'email' => ($email === null || $email === '') ? null : $this->dbTools->db->escape($email),
+                    'phone' => ($phone === null || $phone === '') ? null : $this->dbTools->db->escape($phone),
+                ],
+                $this->consentColumns($consentGivenAt, $consentLanguage)
+            ),
             true // store the empty claim id/password/contact as SQL NULL, not ''
         );
+    }
+
+    /**
+     * Consent columns are recorded together from the moment the customer submitted the form (captured
+     * by the controller, NOT date_add: creating the return can lag behind the consent, e.g. the Packeta
+     * API round-trip or waiting for e-shop approval). Both stay NULL when no consent was given
+     * (e.g. admin-created returns).
+     *
+     * @return array{consent_at: string|null, consent_language: string|null}
+     */
+    private function consentColumns(?string $consentGivenAt, ?string $consentLanguage): array
+    {
+        $given = $consentGivenAt !== null && $consentGivenAt !== '' && $consentLanguage !== null && $consentLanguage !== '';
+
+        return [
+            'consent_at' => $given ? $consentGivenAt : null,
+            'consent_language' => $given ? $this->dbTools->db->escape($consentLanguage) : null,
+        ];
     }
 
     /**
@@ -245,6 +277,8 @@ class ReturnRepository
             `date_add` datetime NOT NULL,
             `email` varchar(255) NULL,
             `phone` varchar(255) NULL,
+            `consent_at` datetime NULL,
+            `consent_language` varchar(2) NULL,
             PRIMARY KEY (`id_return`),
             KEY `idx_id_order` (`id_order`)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8;';

--- a/packetery/libs/Tools/FrontAssetPolicy.php
+++ b/packetery/libs/Tools/FrontAssetPolicy.php
@@ -36,6 +36,11 @@ class FrontAssetPolicy
      */
     public function needsStylesheet(?string $phpSelf, string $pageName): bool
     {
-        return $this->needsCheckoutAssets($phpSelf) || in_array($pageName, self::RETURNS_PAGE_NAMES, true);
+        return $this->needsCheckoutAssets($phpSelf) || $this->needsReturnsScript($pageName);
+    }
+
+    public function needsReturnsScript(string $pageName): bool
+    {
+        return in_array($pageName, self::RETURNS_PAGE_NAMES, true);
     }
 }

--- a/packetery/packetery.php
+++ b/packetery/packetery.php
@@ -1025,6 +1025,10 @@ class Packetery extends CarrierModule
             $this->registerFrontStylesheet();
         }
 
+        if ($assetPolicy->needsReturnsScript($controller->getPageName())) {
+            $this->registerReturnsScript();
+        }
+
         if (!$assetPolicy->needsCheckoutAssets($controller->php_self)) {
             return;
         }
@@ -1054,6 +1058,19 @@ class Packetery extends CarrierModule
             $uri = $this->_path . 'views/js/' . $file;
             $controllerWrapper->registerJavascript(sha1($uri), $uri, ['position' => 'bottom', 'priority' => 80, 'server' => $jsServer]);
         }
+    }
+
+    private function registerReturnsScript(): void
+    {
+        $jsServer = self::LOCAL;
+        $jsPath = $this->_path . 'views/js/return.js';
+        if (!Configuration::get('PS_JS_THEME_CACHE')) {
+            $jsPath .= '?v=' . $this->version;
+            $jsServer = self::REMOTE;
+        }
+
+        $controllerWrapper = $this->diContainer->get(Packetery\Tools\ControllerWrapper::class);
+        $controllerWrapper->registerJavascript('packetery-return', $jsPath, ['position' => 'bottom', 'priority' => 80, 'server' => $jsServer]);
     }
 
     private function registerFrontStylesheet(): void
@@ -1650,6 +1667,12 @@ class Packetery extends CarrierModule
 
         [$prefillEmail, $prefillPhone] = $this->getReturnContactPrefill((int) $orderId);
 
+        /** @var Packetery\Returns\ReturnConsentProvider $consentProvider */
+        $consentProvider = $this->diContainer->get(Packetery\Returns\ReturnConsentProvider::class);
+        /** @var Language $language */
+        $language = $this->context->language;
+        $iso = (string) $language->iso_code;
+
         $flash = Tools::getValue('packetery_return');
         $this->context->smarty->assign(array_merge($sectionData, [
             'returnActionUrl' => $this->context->link->getModuleLink(self::MODULE_SLUG, 'return'),
@@ -1660,7 +1683,10 @@ class Packetery extends CarrierModule
             'returnFlashCreated' => ($flash === 'created'),
             'returnFlashPending' => ($flash === 'pending'),
             'returnFlashExists' => ($flash === 'exists'),
+            'returnFlashConsent' => ($flash === 'consent'),
             'returnFlashError' => ($flash === 'error'),
+            'consentTermsTag' => $consentProvider->getTermsLinkOpenTag($iso),
+            'consentPrivacyTag' => $consentProvider->getPrivacyPolicyLinkOpenTag($iso),
         ]));
 
         return $sectionData['returnState'];

--- a/packetery/translations/cs.php
+++ b/packetery/translations/cs.php
@@ -490,5 +490,8 @@ $_MODULE['<{packetery}prestashop>_returnhistorytable_0eceeb45861f9585dd7a97a3e36
 $_MODULE['<{packetery}prestashop>_returnhistorytable_ec53a8c4f07baed5d8825072c89799be'] = 'Stav';
 $_MODULE['<{packetery}prestashop>_returnhistorytable_e65b1f3c480c7fae2eb5e1620e862e5f'] = 'Číslo vratky';
 $_MODULE['<{packetery}prestashop>_returnhistorytable_22c6e79cf99308b6aeba432e6855a430'] = 'Podací kód';
+$_MODULE['<{packetery}prestashop>_returnconsentcheckbox_679b9371db44bbb30a095fb5e2369cc5'] = 'Souhlasím s [1]pravidly pro použití služby[/1] a beru na vědomí [2]Zásady zpracování osobních údajů[/2] nezbytných pro vrácení zásilky.';
+$_MODULE['<{packetery}prestashop>display_order_detail_2fb2c25fb98aaece444d3483e609b76b'] = 'Pro vytvoření vratky musíte souhlasit s pravidly pro použití služby a zásadami zpracování osobních údajů.';
+$_MODULE['<{packetery}prestashop>return_2fb2c25fb98aaece444d3483e609b76b'] = 'Pro vytvoření vratky musíte souhlasit s pravidly pro použití služby a zásadami zpracování osobních údajů.';
 $_MODULE['<{packetery}prestashop>pendingreturnsnotice_85f9a105700b2f5345cf172edb09f9a6'] = 'Vratky Zásilkovny čekají na vaše schválení: %count%.';
 $_MODULE['<{packetery}prestashop>pendingreturnsnotice_65caba5d1440a9c07153e3539aa1b445'] = 'Zobrazit vratky';

--- a/packetery/translations/sk.php
+++ b/packetery/translations/sk.php
@@ -490,5 +490,8 @@ $_MODULE['<{packetery}prestashop>_returnhistorytable_0eceeb45861f9585dd7a97a3e36
 $_MODULE['<{packetery}prestashop>_returnhistorytable_ec53a8c4f07baed5d8825072c89799be'] = 'Stav';
 $_MODULE['<{packetery}prestashop>_returnhistorytable_e65b1f3c480c7fae2eb5e1620e862e5f'] = 'Číslo vrátenia';
 $_MODULE['<{packetery}prestashop>_returnhistorytable_22c6e79cf99308b6aeba432e6855a430'] = 'Podací kód';
+$_MODULE['<{packetery}prestashop>_returnconsentcheckbox_679b9371db44bbb30a095fb5e2369cc5'] = 'Súhlasím s [1]pravidlami pre použitie služby[/1] a beriem na vedomie [2]Zásady spracúvania osobných údajov[/2] nevyhnutných pre vrátenie zásielky.';
+$_MODULE['<{packetery}prestashop>display_order_detail_2fb2c25fb98aaece444d3483e609b76b'] = 'Na vytvorenie vrátenia musíte súhlasiť s pravidlami pre použitie služby a zásadami spracúvania osobných údajov.';
+$_MODULE['<{packetery}prestashop>return_2fb2c25fb98aaece444d3483e609b76b'] = 'Na vytvorenie vrátenia musíte súhlasiť s pravidlami pre použitie služby a zásadami spracúvania osobných údajov.';
 $_MODULE['<{packetery}prestashop>pendingreturnsnotice_85f9a105700b2f5345cf172edb09f9a6'] = 'Vrátenia Packety čakajú na vaše schválenie: %count%.';
 $_MODULE['<{packetery}prestashop>pendingreturnsnotice_65caba5d1440a9c07153e3539aa1b445'] = 'Zobraziť vrátenia';

--- a/packetery/views/css/front.css
+++ b/packetery/views/css/front.css
@@ -122,3 +122,26 @@
     background-color: #e5e5e5;
     color: #777;
 }
+
+/* Return form required fields; the checkbox label has the asterisk in front, like the checkout terms checkbox */
+.packetery-required:after {
+    content: " *";
+    color: var(--bs-danger, #dc3545);
+}
+
+.form-check-label.packetery-required:after {
+    content: none;
+}
+
+.form-check-label.packetery-required:before {
+    content: "* ";
+    color: var(--bs-danger, #dc3545);
+}
+
+.packetery-was-validated input:invalid {
+    border-color: var(--bs-danger, #dc3545);
+}
+
+.packetery-was-validated input:invalid ~ .form-check-label {
+    color: var(--bs-danger, #dc3545);
+}

--- a/packetery/views/js/return.js
+++ b/packetery/views/js/return.js
@@ -1,0 +1,18 @@
+/**
+ * @copyright 2015-2026 Packeta s.r.o.
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+(function () {
+    'use strict';
+
+    document.querySelectorAll('form.packetery-return-form').forEach(function (form) {
+        form.addEventListener('submit', function (event) {
+            form.classList.add('packetery-was-validated');
+            if (!form.checkValidity()) {
+                event.preventDefault();
+                form.reportValidity();
+            }
+        });
+    });
+})();

--- a/packetery/views/templates/front/return/guest.tpl
+++ b/packetery/views/templates/front/return/guest.tpl
@@ -31,17 +31,18 @@
             {if $guestHistory && $guestHistory|@count > 0}
                 {include file="module:packetery/views/templates/hook/_returnHistoryTable.tpl" history=$guestHistory}
             {/if}
-            <form action="{$returnActionUrl|escape:'htmlall':'UTF-8'}" method="post">
+            <form action="{$returnActionUrl|escape:'htmlall':'UTF-8'}" method="post" class="packetery-return-form" novalidate>
                 <input type="hidden" name="packetery_order_reference" value="{$guestReference|escape:'htmlall':'UTF-8'}">
                 <input type="hidden" name="token" value="{$returnToken|escape:'htmlall':'UTF-8'}">
                 <div class="mb-3">
-                    <label for="packetery_email">{l s='E-mail address' mod='packetery'}</label>
+                    <label for="packetery_email" class="packetery-required">{l s='E-mail address' mod='packetery'}</label>
                     <input type="email" id="packetery_email" name="packetery_email" class="form-control" value="{$guestEmail|escape:'htmlall':'UTF-8'}" required>
                 </div>
                 <div class="mb-3">
                     <label for="packetery_phone">{l s='Phone' mod='packetery'}</label>
                     <input type="text" id="packetery_phone" name="packetery_phone" class="form-control" value="{$guestPhone|escape:'htmlall':'UTF-8'}">
                 </div>
+                {include file="module:packetery/views/templates/hook/_returnConsentCheckbox.tpl" consentTermsTag=$consentTermsTag consentPrivacyTag=$consentPrivacyTag}
                 <button type="submit" name="submitPacketeryReturnGuestCreate" class="btn btn-primary">
                     {l s='Return goods via Packeta' mod='packetery'}
                 </button>
@@ -60,13 +61,13 @@
                 {include file="module:packetery/views/templates/hook/_returnHistoryTable.tpl" history=$guestHistory}
             {/if}
             <p>{l s='Enter your order number and e-mail address to return goods via Packeta.' mod='packetery'}</p>
-            <form action="{$returnActionUrl|escape:'htmlall':'UTF-8'}" method="post">
+            <form action="{$returnActionUrl|escape:'htmlall':'UTF-8'}" method="post" class="packetery-return-form" novalidate>
                 <div class="mb-3">
-                    <label for="packetery_order_reference">{l s='Order number' mod='packetery'}</label>
+                    <label for="packetery_order_reference" class="packetery-required">{l s='Order number' mod='packetery'}</label>
                     <input type="text" id="packetery_order_reference" name="packetery_order_reference" class="form-control" value="{$guestReference|escape:'htmlall':'UTF-8'}" required>
                 </div>
                 <div class="mb-3">
-                    <label for="packetery_email">{l s='E-mail address' mod='packetery'}</label>
+                    <label for="packetery_email" class="packetery-required">{l s='E-mail address' mod='packetery'}</label>
                     <input type="email" id="packetery_email" name="packetery_email" class="form-control" value="{$guestEmail|escape:'htmlall':'UTF-8'}" required>
                 </div>
                 <input type="hidden" name="token" value="{$returnToken|escape:'htmlall':'UTF-8'}">

--- a/packetery/views/templates/hook/_returnConsentCheckbox.tpl
+++ b/packetery/views/templates/hook/_returnConsentCheckbox.tpl
@@ -1,0 +1,15 @@
+{**
+ * @copyright 2015-2026 Packeta s.r.o.
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *
+ * Mandatory return consent checkbox, shared by the registered (order detail) and guest return forms.
+ * Expects consentTermsTag and consentPrivacyTag (the opening <a> tags, built in ReturnConsentProvider).
+ * The links go inside the sentence via PS `tags`, so the translation stays one legal sentence
+ * (postProcessTranslation inserts them after escaping; works on 1.7.8/8/9).
+ *}
+<div class="form-check mb-3">
+    <input type="checkbox" id="packetery_return_consent" name="packetery_return_consent" value="1" class="form-check-input" required>
+    <label class="form-check-label packetery-required" for="packetery_return_consent">
+        {l s='I agree to the [1]Terms of Service[/1] and acknowledge the [2]Privacy Policy[/2] governing the personal data required to process the return.' tags=[$consentTermsTag, $consentPrivacyTag] mod='packetery'}
+    </label>
+</div>

--- a/packetery/views/templates/hook/display_order_detail.tpl
+++ b/packetery/views/templates/hook/display_order_detail.tpl
@@ -16,6 +16,8 @@
         <p class="alert alert-success">{l s='Your return request has been submitted and is being processed by the e-shop.' mod='packetery'}</p>
     {elseif $returnFlashExists}
         <p class="alert alert-info">{l s='No new return has been created.' mod='packetery'}</p>
+    {elseif $returnFlashConsent}
+        <p class="alert alert-danger">{l s='You must agree to the Terms of Service and the Privacy Policy to create a return.' mod='packetery'}</p>
     {elseif $returnFlashError}
         <p class="alert alert-danger">{l s='The return could not be created. Please check your e-mail and phone number and try again, or contact the e-shop.' mod='packetery'}</p>
     {/if}
@@ -30,17 +32,18 @@
         <p>{l s='Your return request is being processed by the e-shop.' mod='packetery'}</p>
     {elseif $returnState == 'form'}
         <h4>{l s='Return goods' mod='packetery'}</h4>
-        <form action="{$returnActionUrl|escape:'htmlall':'UTF-8'}" method="post">
+        <form action="{$returnActionUrl|escape:'htmlall':'UTF-8'}" method="post" class="packetery-return-form" novalidate>
             <input type="hidden" name="id_order" value="{$returnOrderId|intval}">
             <input type="hidden" name="token" value="{$returnToken|escape:'htmlall':'UTF-8'}">
             <div class="mb-3">
-                <label for="packetery_return_email">{l s='E-mail address' mod='packetery'}</label>
+                <label for="packetery_return_email" class="packetery-required">{l s='E-mail address' mod='packetery'}</label>
                 <input type="email" id="packetery_return_email" name="packetery_email" class="form-control" value="{$returnPrefillEmail|escape:'htmlall':'UTF-8'}" required>
             </div>
             <div class="mb-3">
                 <label for="packetery_return_phone">{l s='Phone' mod='packetery'}</label>
                 <input type="text" id="packetery_return_phone" name="packetery_phone" class="form-control" value="{$returnPrefillPhone|escape:'htmlall':'UTF-8'}">
             </div>
+            {include file="module:packetery/views/templates/hook/_returnConsentCheckbox.tpl" consentTermsTag=$consentTermsTag consentPrivacyTag=$consentPrivacyTag}
             <button type="submit" name="submitPacketeryReturn" class="btn btn-primary">
                 {l s='Return goods via Packeta' mod='packetery'}
             </button>

--- a/tests/Unit/Returns/ReturnConsentProviderTest.php
+++ b/tests/Unit/Returns/ReturnConsentProviderTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @author    Packeta s.r.o. <e-commerce.support@packeta.com>
+ * @copyright 2015-2026 Packeta s.r.o.
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Packetery\Tests\Unit\Returns;
+
+use Packetery\Returns\ReturnConsentProvider;
+use PHPUnit\Framework\TestCase;
+
+class ReturnConsentProviderTest extends TestCase
+{
+    /** @var ReturnConsentProvider */
+    private $provider;
+
+    protected function setUp(): void
+    {
+        $this->provider = new ReturnConsentProvider();
+    }
+
+    public function testPrivacyPolicyUrlIsLocalisedForKnownLanguages(): void
+    {
+        $this->assertStringContainsString('GDPR.pdf', $this->provider->getPrivacyPolicyUrl('cs'));
+        $this->assertStringContainsString('SK_Zasady', $this->provider->getPrivacyPolicyUrl('sk'));
+        $this->assertStringContainsString('Privacy-Policy', $this->provider->getPrivacyPolicyUrl('en'));
+    }
+
+    public function testPrivacyPolicyUrlFallsBackToEnglishForUnknownLanguage(): void
+    {
+        $this->assertSame(
+            $this->provider->getPrivacyPolicyUrl('en'),
+            $this->provider->getPrivacyPolicyUrl('de')
+        );
+    }
+
+    public function testTermsUrlIsLocalisedForKnownLanguages(): void
+    {
+        $this->assertStringContainsString('VOP_Zasilkovna', $this->provider->getTermsUrl('cs'));
+        $this->assertStringContainsString('SK_Obchodne_podmienky', $this->provider->getTermsUrl('sk'));
+        $this->assertStringContainsString('GTC_Zasilkovna', $this->provider->getTermsUrl('en'));
+    }
+
+    public function testTermsUrlFallsBackToEnglishForUnknownLanguage(): void
+    {
+        $this->assertSame(
+            $this->provider->getTermsUrl('en'),
+            $this->provider->getTermsUrl('de')
+        );
+    }
+
+    public function testLinkOpenTagsWrapTheLocalisedUrl(): void
+    {
+        $tag = $this->provider->getPrivacyPolicyLinkOpenTag('cs');
+
+        $this->assertStringStartsWith('<a href="', $tag);
+        $this->assertStringContainsString($this->provider->getPrivacyPolicyUrl('cs'), $tag);
+        $this->assertStringContainsString('target="_blank"', $tag);
+        $this->assertStringContainsString('rel="noopener noreferrer"', $tag);
+        $this->assertStringContainsString('<a href="', $this->provider->getTermsLinkOpenTag('cs'));
+    }
+}

--- a/tests/Unit/Returns/ReturnEntityTest.php
+++ b/tests/Unit/Returns/ReturnEntityTest.php
@@ -23,6 +23,8 @@ class ReturnEntityTest extends TestCase
             'status' => ReturnEntity::STATUS_CREATED,
             'source' => ReturnEntity::SOURCE_ADMIN,
             'date_add' => '2026-07-09 12:00:00',
+            'consent_at' => '2026-07-09 11:59:58',
+            'consent_language' => 'cs',
         ]);
 
         $this->assertSame(5, $return->getIdReturn());
@@ -32,6 +34,8 @@ class ReturnEntityTest extends TestCase
         $this->assertSame('created', $return->getStatus());
         $this->assertSame('admin', $return->getSource());
         $this->assertSame('2026-07-09 12:00:00', $return->getDateAdd());
+        $this->assertSame('2026-07-09 11:59:58', $return->getConsentGivenAt());
+        $this->assertSame('cs', $return->getConsentLanguage());
     }
 
     public function testFromDbRowMapsMissingClaimPasswordToNull(): void
@@ -46,5 +50,20 @@ class ReturnEntityTest extends TestCase
         ]);
 
         $this->assertNull($return->getClaimPassword());
+    }
+
+    public function testFromDbRowMapsMissingConsentToNull(): void
+    {
+        $return = ReturnEntity::fromDbRow([
+            'id_return' => '7',
+            'id_order' => '42',
+            'claim_id' => 'C000000000002',
+            'status' => ReturnEntity::STATUS_CREATED,
+            'source' => ReturnEntity::SOURCE_ADMIN,
+            'date_add' => '2026-07-09 12:00:00',
+        ]);
+
+        $this->assertNull($return->getConsentGivenAt());
+        $this->assertNull($return->getConsentLanguage());
     }
 }

--- a/tests/Unit/Returns/ReturnRepositoryTest.php
+++ b/tests/Unit/Returns/ReturnRepositoryTest.php
@@ -141,4 +141,55 @@ class ReturnRepositoryTest extends TestCase
 
         $this->assertSame(2, (new ReturnRepository($dbTools))->countPending());
     }
+
+    public function testInsertStoresTheConsentTimestampAndLanguage(): void
+    {
+        $data = $this->captureInsert(function (ReturnRepository $repository): void {
+            $repository->insert(42, 'C1', 'pw', ReturnEntity::STATUS_CREATED, ReturnEntity::SOURCE_CUSTOMER, '2026-07-09 11:59:58', 'cs');
+        });
+
+        $this->assertSame('2026-07-09 11:59:58', $data['consent_at']);
+        $this->assertSame('cs', $data['consent_language']);
+    }
+
+    public function testInsertStoresNullConsentWhenNoneWasGiven(): void
+    {
+        $data = $this->captureInsert(function (ReturnRepository $repository): void {
+            $repository->insert(42, 'C1', 'pw', ReturnEntity::STATUS_CREATED, ReturnEntity::SOURCE_ADMIN);
+        });
+
+        $this->assertNull($data['consent_at']);
+        $this->assertNull($data['consent_language']);
+    }
+
+    public function testInsertPendingStoresTheConsentTimestampAndLanguage(): void
+    {
+        $data = $this->captureInsert(function (ReturnRepository $repository): void {
+            $repository->insertPending(42, ReturnEntity::SOURCE_CUSTOMER, 'a@b.cz', '777', '2026-07-09 11:59:58', 'sk');
+        });
+
+        $this->assertSame('2026-07-09 11:59:58', $data['consent_at']);
+        $this->assertSame('sk', $data['consent_language']);
+    }
+
+    /**
+     * @param callable(ReturnRepository): void $call
+     *
+     * @return array<string, mixed> the row passed to DbTools::insert()
+     */
+    private function captureInsert(callable $call): array
+    {
+        $captured = [];
+        $dbTools = $this->createStub(DbTools::class);
+        $dbTools->db = new \Db();
+        $dbTools->method('insert')->willReturnCallback(static function ($table, $data) use (&$captured): bool {
+            $captured = $data;
+
+            return true;
+        });
+
+        $call(new ReturnRepository($dbTools));
+
+        return $captured;
+    }
 }


### PR DESCRIPTION
Povinný souhlas s pravidly použití služby a zásadami zpracování osobních údajů na obou
zákaznických formulářích vratky. Kontrola je server-side — bez souhlasu nevznikne ani
pending vratka. K vratce se ukládá `consent_at` + `consent_language`; čas se bere v controlleru
při odeslání formuláře, protože vznik vratky může zaostávat (volání Packeta API, u pending
i dny). Migrace není potřeba, tabulka vzniká celá až v `upgrade-3.6.0.php`.

Odkazy jsou v překládané větě přes PS `tags`, ne `html=1` — ten starší `smartyTranslate`
u modulových překladů ignoruje. Otevírací tag staví `ReturnConsentProvider` v PHP; inline
v `{l}` by string náš překladový scanner kvůli složené závorce přeskočil.

Označení a zvýraznění povinných polí je vlastní (`return.js` + `front.css`) — hummingbird vzor
na classic nefunguje.

CHANGE_LOG záměrně bez záznamu, vratky mají jeden souhrnný záznam za celou fičuru ve 3.6.
