### PR TITLE
Fix null hook return for virtual products

### DIFF
--- a/packetery/packetery.php
+++ b/packetery/packetery.php
@@ -1779,7 +1779,7 @@ class Packetery extends CarrierModule
      *
      * @param array $params Hook parameter
      *
-     * @return false|string|void
+     * @return false|string
      *
      * @throws Packetery\Exceptions\DatabaseException
      * @throws ReflectionException
@@ -1799,7 +1799,7 @@ class Packetery extends CarrierModule
         $product = new Product($idProduct);
 
         if (Validate::isLoadedObject($product) === false || $product->is_virtual) {
-            return;
+            return '';
         }
 
         $isAgeVerificationRequired = null;


### PR DESCRIPTION
## Summary

* Return an empty string from `hookDisplayAdminProductsExtra()` when the product is virtual or invalid.
* Update the PHPDoc return type to reflect that the method no longer returns `void`.

## Reason

PrestaShop 9.1 applies the `raw_purified` Twig filter to the content returned by product extra modules. The filter requires a string, but the Packetery hook previously returned `null` for virtual products, causing a `TypeError` while rendering the product edit page.

Fixes #473

## Testing

Automated checks:

* `vendor/bin/ec packetery/packetery.php`
* `vendor/bin/phpcs --standard=./phpcs.xml packetery/packetery.php`
* `vendor/bin/php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.dist.php packetery/packetery.php`
* `composer phpstan`

Manual regression test on PrestaShop 9.1.0 with PHP 8.3.20:

* Virtual product edit page loads without the `rawPurifier()` exception.
* Standard product edit page still loads and displays the Packetery product extension correctly.

## Branch note

The same null return is also present in the `v3.5` and `v3.6` branches. This pull request targets `main` because the issue is reproducible in the currently released version 3.4.0.
